### PR TITLE
Fix PWA manifest assets and guard initials rendering

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,52 +10,16 @@
   "scope": "/",
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
-      "sizes": "72x72",
-      "type": "image/png",
+      "src": "/icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
       "purpose": "any"
     },
     {
-      "src": "/icons/icon-96x96.png",
-      "sizes": "96x96",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-128x128.png",
-      "sizes": "128x128",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-152x152.png",
-      "sizes": "152x152",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "/icons/icon-384x384.png",
-      "sizes": "384x384",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/icons/icon-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any maskable"
+      "src": "/icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
     }
   ],
   "categories": [
@@ -91,9 +55,9 @@
       "url": "/?mode=parent",
       "icons": [
         {
-          "src": "/icons/shortcut-parent.png",
-          "sizes": "192x192",
-          "type": "image/png"
+          "src": "/icons/icon.svg",
+          "sizes": "any",
+          "type": "image/svg+xml"
         }
       ]
     }
@@ -103,6 +67,11 @@
   "share_target": {
     "action": "/",
     "method": "GET",
-    "enctype": "application/x-www-form-urlencoded"
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
   }
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -4,10 +4,8 @@ const RUNTIME_CACHE = 'chorequest-runtime';
 const PRECACHE_URLS = [
   '/',
   '/index.html',
-  '/src/main.tsx',
-  '/src/main.css',
-  '/src/index.css',
-  '/manifest.json'
+  '/manifest.json',
+  '/icons/icon.svg'
 ];
 
 self.addEventListener('install', (event) => {

--- a/src/components/ChildCard.tsx
+++ b/src/components/ChildCard.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Pencil, Trash, Star, ListChecks, CalendarBlank } from '@phosphor-icons/react'
 import { Child, Category } from '@/lib/types'
+import { getInitialsFromName } from '@/lib/helpers'
 
 interface ChildCardProps {
   child: Child
@@ -17,12 +18,7 @@ interface ChildCardProps {
 }
 
 export function ChildCard({ child, totalPoints, onEdit, onDelete, onClick, onDownloadICS, categoryPoints, categories = [] }: ChildCardProps) {
-  const initials = child.name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2)
+  const initials = getInitialsFromName(child.name)
 
   return (
     <Card className="hover:shadow-lg transition-shadow">

--- a/src/components/ChildChoreView.tsx
+++ b/src/components/ChildChoreView.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { CheckCircle, Circle, Calendar, Star, ShoppingCart, SunHorizon, MoonStars, Warning, Users, Trophy, ArrowCounterClockwise, Clock, Timer, ClockClockwise, ChartLine } from '@phosphor-icons/react'
 import { Child, Chore, ChoreAssignment, ChoreCompletion, CelebrationSettings, CelebrationAnimation, Reward, GoalTracker, Category, WeatherData } from '@/lib/types'
-import { isChoreCompleted, isChoreActive, isChoreAvailableNow, isChoreMissed, getCurrentTimeOfDay, isChoreCompletedForTimeOfDay, isChoreActiveToday, getChorePointsForChild, getChoreCategoryPointsForChild, sortChoresByDesiredTime, getRandomCelebrationAnimation, getTimeWindowStatus, formatTime12Hour, getRewardCostForChild, formatDuration, getCategoryCompletionProgress, getShareableChoreCompletionCount, isShareableChoreFullyCompleted, hasChildCompletedShareableChore } from '@/lib/helpers'
+import { isChoreCompleted, isChoreActive, isChoreAvailableNow, isChoreMissed, getCurrentTimeOfDay, isChoreCompletedForTimeOfDay, isChoreActiveToday, getChorePointsForChild, getChoreCategoryPointsForChild, sortChoresByDesiredTime, getRandomCelebrationAnimation, getTimeWindowStatus, formatTime12Hour, getRewardCostForChild, formatDuration, getCategoryCompletionProgress, getShareableChoreCompletionCount, isShareableChoreFullyCompleted, hasChildCompletedShareableChore, getInitialsFromName } from '@/lib/helpers'
 import { shouldShowChore } from '@/lib/weatherChoreHelper'
 import { ChoreCompletionCelebration } from './Celebration'
 import { GoalProgress } from './GoalProgress'
@@ -271,12 +271,7 @@ export function ChildChoreView({
     }
   }, [childChores, completions, child.id, currentTimeOfDay])
 
-  const initials = child.name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2)
+  const initials = getInitialsFromName(child.name)
 
   const handleComplete = (chore: Chore, assignment: ChoreAssignment, timeOfDay?: 'am' | 'pm') => {
     if (celebrationSettings.enabled) {

--- a/src/components/ChildSelector.tsx
+++ b/src/components/ChildSelector.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Gear, Trophy, Clock, SpeakerHigh, Fingerprint } from '@phosphor-icons/react'
 import { Child, GoalTracker, Reward, Category, ChoreAssignment, Chore, ChoreCompletion, WeatherSettings, SpeechSettings, BiometricSettings } from '@/lib/types'
-import { getRewardCostForChild, getNextUpcomingChore, formatTime12Hour, formatDuration } from '@/lib/helpers'
+import { getRewardCostForChild, getNextUpcomingChore, formatTime12Hour, formatDuration, getInitialsFromName } from '@/lib/helpers'
 import { WeatherDisplay } from '@/components/WeatherDisplay'
 import { isStandalone } from '@/lib/pwaHelper'
 
@@ -137,12 +137,7 @@ export function ChildSelector({
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {childrenList.map((child, index) => {
-            const initials = child.name
-              .split(' ')
-              .map((n) => n[0])
-              .join('')
-              .toUpperCase()
-              .slice(0, 2)
+            const initials = getInitialsFromName(child.name)
 
             const childGoal = trackedGoals.find(g => g.childId === child.id)
             const goalReward = childGoal ? rewards.find(r => r.id === childGoal.rewardId) : null

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -35,6 +35,25 @@ export function getWeekNumber(date: Date): number {
   return Math.ceil((((d.getTime() - yearStart.getTime()) / 86400000) + 1) / 7)
 }
 
+export function getInitialsFromName(name?: string, fallback: string = '?'): string {
+  if (!name) {
+    return fallback
+  }
+
+  const trimmed = name.trim()
+  if (!trimmed) {
+    return fallback
+  }
+
+  return trimmed
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
 export function isRepeatPatternActiveToday(assignment: ChoreAssignment): boolean {
   if (!assignment.repeatPattern) {
     return true


### PR DESCRIPTION
### Motivation
- Browser console showed PWA manifest and service worker errors and a runtime crash from calling `split` on an undefined name, so the manifest, precache list and initials handling needed fixing.

### Description
- Update `public/manifest.json` to reference the real SVG asset (`/icons/icon.svg`) and add the required `share_target.params` to satisfy manifest validation.
- Trim `public/service-worker.js` precache URLs to remove non-public `/src/*` entries and add `/icons/icon.svg` to avoid `cache.addAll` failures when resources are missing.
- Add a safe helper `getInitialsFromName(name?: string, fallback: string = '?')` in `src/lib/helpers.ts` and replace ad-hoc `.split` logic with `getInitialsFromName` in `src/components/ChildCard.tsx`, `src/components/ChildSelector.tsx`, and `src/components/ChildChoreView.tsx` to prevent runtime errors.
- Changes touch `public/manifest.json`, `public/service-worker.js`, `src/lib/helpers.ts`, `src/components/ChildCard.tsx`, `src/components/ChildSelector.tsx`, and `src/components/ChildChoreView.tsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d393cb74c83329420ccd05a41ca22)