### PR TITLE
Normalize stored parent PIN values on load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,6 +142,16 @@ function App() {
   const [speechSettings, setSpeechSettings] = useKV<SpeechSettings>('speech-settings', {
     enabled: true,
   })
+  const normalizedParentPin = (() => {
+    if (typeof parentPin !== 'string') {
+      return parentPin ?? null
+    }
+    const trimmedPin = parentPin.trim()
+    if (!trimmedPin || trimmedPin === 'null' || trimmedPin === 'undefined') {
+      return null
+    }
+    return trimmedPin
+  })()
   const [currentIP, setCurrentIP] = useState<string | null>(null)
   const [ipAccessGranted, setIPAccessGranted] = useState<boolean>(false)
   const [isCheckingIP, setIsCheckingIP] = useState<boolean>(true)
@@ -183,6 +193,12 @@ function App() {
   useEffect(() => {
     initializePWA()
   }, [])
+
+  useEffect(() => {
+    if (parentPin !== normalizedParentPin) {
+      setParentPin(normalizedParentPin)
+    }
+  }, [parentPin, normalizedParentPin, setParentPin])
 
   // Validate and fix pinSecurity data structure - one-time migration
   useEffect(() => {
@@ -1391,7 +1407,7 @@ Please log in to ChoreQuest to approve or reject this completion.
           purchases={safePurchases}
           history={safeHistory}
           dismissedMissedChores={safeDismissedMissedChores}
-          parentPin={parentPin ?? null}
+          parentPin={normalizedParentPin}
           celebrationSettings={celebrationSettings || { enabled: true, animations: { confetti: true, fireworks: true, sparkles: true, stars: true, bubbles: true, hearts: true }, showUndoButton: true }}
           biometricSettings={biometricSettings || { enabled: false, credentials: [], requirePinFallback: true, quickUnlockOnPWA: true }}
           categories={safeCategories}
@@ -1581,7 +1597,7 @@ Please log in to ChoreQuest to approve or reject this completion.
         open={showPinDialog}
         onClose={() => setShowPinDialog(false)}
         onSuccess={handlePinSuccess}
-        storedPin={parentPin ?? null}
+        storedPin={normalizedParentPin}
         onSetPin={handleSetPin}
         pinSecurity={pinSecurity || { attempts: [], lockedUntil: null, failedAttempts: 0 }}
         onUpdatePinSecurity={(security) => setPinSecurity(security)}


### PR DESCRIPTION
### Motivation

- Fresh deployments could misinterpret stored placeholder values (e.g. empty strings or literal `'null'`/`'undefined'`) as a configured parent PIN, preventing the initial PIN setup flow from appearing.
- The change ensures Parent Mode and the PIN dialog see a consistent `null` when no valid PIN is configured so onboarding behaves correctly.

### Description

- Add a computed `normalizedParentPin` that trims `parentPin` and treats empty/placeholder strings as `null`.
- Persist the normalized value back to storage with `setParentPin` in a `useEffect` so the normalized state is saved and reused.
- Route `normalizedParentPin` into parent flows by replacing previous `parentPin ?? null` usages for `ParentPanel` and `ParentPinDialog` props.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d4309b10c833298eaaf11414c1d5e)