### PR TITLE
Fix Parent PIN dialog prompt when no PIN is set

### DIFF
--- a/src/components/ParentPinDialog.tsx
+++ b/src/components/ParentPinDialog.tsx
@@ -42,7 +42,7 @@ export function ParentPinDialog({
   const [pin, setPin] = useState('')
   const [confirmPin, setConfirmPin] = useState('')
   const [error, setError] = useState('')
-  const [isSettingPin, setIsSettingPin] = useState(false)
+  const [isSettingPin, setIsSettingPin] = useState(() => !storedPin)
   const [lockoutTime, setLockoutTime] = useState<number | null>(null)
   const [isAuthenticating, setIsAuthenticating] = useState(false)
   const [showPinInput, setShowPinInput] = useState(false)


### PR DESCRIPTION
### Motivation
- The Parent PIN dialog defaulted `isSettingPin` to `false`, which caused the UI to display "Enter Parent PIN" even when no PIN existed; it should prompt the user to set a PIN instead.

### Description
- Initialize `isSettingPin` from `storedPin` by using `useState(() => !storedPin)` in `src/components/ParentPinDialog.tsx` so the initial render shows the correct `Set Parent PIN` prompt when appropriate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d503984988332a2283b2de9742540)