### PR TITLE
Fix modal overflow scrolling

### DIFF
--- a/changes/ef5c0cb2-f081-4d88-b45b-7dce08422740.json
+++ b/changes/ef5c0cb2-f081-4d88-b45b-7dce08422740.json
@@ -1,0 +1,7 @@
+{
+  "guid": "ef5c0cb2-f081-4d88-b45b-7dce08422740",
+  "occurred_at": "2026-01-31T23:22:04Z",
+  "change_type": "Fix",
+  "summary": "Allow dialog content to scroll when it exceeds the viewport height.",
+  "content_hash": "3b0c5019f3e8cc7c060c5bc00847f5ed3d7e25a8e72ade47b539f4a4f2b5d30c"
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -54,7 +54,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-h-[calc(100vh-2rem)] max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-h-[calc(100vh-2rem)] max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
### Motivation
- Users could not reach buttons when dialogs were taller than the viewport because dialog content did not scroll.

### Description
- Constrain dialog and alert dialog content height by adding `max-h-[calc(100vh-2rem)]` to the content containers to keep modals within the viewport.
- Enable vertical scrolling for tall modals by adding `overflow-y-auto` to both `Dialog` and `AlertDialog` content classNames in `src/components/ui/dialog.tsx` and `src/components/ui/alert-dialog.tsx`.
- Add a changelog entry file at `changes/ef5c0cb2-f081-4d88-b45b-7dce08422740.json` describing the fix.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app (local URL printed to console). 
- Ran an automated Playwright script that navigated to the running app and captured a screenshot saved as `artifacts/modal-scroll.png`, which demonstrates scrollable modal content and succeeded after retrying on the correct dev port.
- Note that an initial Playwright run to port `4173` failed with `ERR_EMPTY_RESPONSE`, but a subsequent run against the active Vite port succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e8e6bd480832db481ce20034bfc0c)