### PR TITLE
Show child-assigned chores regardless of category `showInUpNext` flag

### DIFF
--- a/changes/be800ca1-ddd0-4f92-841c-0e7d28f3f844.json
+++ b/changes/be800ca1-ddd0-4f92-841c-0e7d28f3f844.json
@@ -1,0 +1,7 @@
+{
+  "guid": "be800ca1-ddd0-4f92-841c-0e7d28f3f844",
+  "occurred_at": "2026-01-31T23:47:54Z",
+  "change_type": "Fix",
+  "summary": "Allow chores hidden from Up Next to still display inside the child chore view.",
+  "content_hash": "43fd9d7406131b9a19ff3529fe07f7f9d2f86fa34cff0e95953dd76b28f56919"
+}

--- a/src/components/ChildChoreView.tsx
+++ b/src/components/ChildChoreView.tsx
@@ -94,32 +94,10 @@ export function ChildChoreView({
     const missed: Array<{ chore: Chore; assignment: ChoreAssignment; timeOfDay?: 'am' | 'pm' }> = []
     const unavailable: Array<{ chore: Chore; assignment: ChoreAssignment; timeOfDay?: 'am' | 'pm'; windowStatus: ReturnType<typeof getTimeWindowStatus> }> = []
 
-    // Create a Map for O(1) category lookup
-    const categoryMap = new Map(categories.map(c => [c.id, c]))
-
-    // Helper function to check if chore should be shown in Up Next
-    const shouldShowInUpNext = (chore: Chore): boolean => {
-      // If chore has no categories, show it by default
-      if (!chore.categoryIds || chore.categoryIds.length === 0) {
-        return true
-      }
-      
-      // Show only if ALL categories have showInUpNext !== false
-      // If ANY category has showInUpNext === false, hide the chore
-      // Missing categories are treated as showInUpNext: true (default behavior)
-      return chore.categoryIds.every(categoryId => {
-        const category = categoryMap.get(categoryId)
-        return !category || category.showInUpNext !== false
-      })
-    }
-
     childChores.forEach((chore) => {
       const assignment = childAssignments.find(a => a.choreId === chore.id)
       if (!assignment) return
-      
-      // Skip chore if all its categories have showInUpNext set to false
-      if (!shouldShowInUpNext(chore)) return
-      
+
       const windowStatus = getTimeWindowStatus(chore)
       
       if (chore.completionType === 'shareable' && chore.maxCompletions) {
@@ -368,7 +346,7 @@ export function ChildChoreView({
   }, [trackedGoal, rewards])
 
   const categoriesWithBonuses = useMemo(() => {
-    return categories.filter(cat => cat.completionBonus && cat.showInUpNext !== false)
+    return categories.filter(cat => cat.completionBonus)
   }, [categories])
 
   const categoryCompletionProgress = useMemo(() => {


### PR DESCRIPTION
### Motivation

- The UI should only hide chores from the Up Next list on the parent/overview cards, not from the full chore list shown after opening a child's card.

### Description

- Removed the `showInUpNext` filtering logic from `src/components/ChildChoreView.tsx` so assigned chores are listed in the child view even if their categories have `showInUpNext: false`.
- Updated `categoriesWithBonuses` in `ChildChoreView` to compute bonus progress from `completionBonus` only, instead of also requiring `showInUpNext` to be true.
- Added a changelog entry at `changes/be800ca1-ddd0-4f92-841c-0e7d28f3f844.json` describing this Fix.

### Testing

- Started the dev server with `npm run dev` and verified the app served (Vite reported the local URL). The server start completed successfully.
- Captured a UI screenshot using a Playwright script which loaded the running dev site and produced `artifacts/up-next-chores.png`, confirming the child chore view renders after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e94739f94832dbd4c449681bd4890)