### PR TITLE
Fix next-up filtering to respect category "Show In Up Next" setting

### DIFF
--- a/changes/b72fbe02-504b-4f2e-866a-2d50b02084e0.json
+++ b/changes/b72fbe02-504b-4f2e-866a-2d50b02084e0.json
@@ -1,0 +1,7 @@
+{
+  "guid": "b72fbe02-504b-4f2e-866a-2d50b02084e0",
+  "occurred_at": "2026-02-01T00:53:06.146962Z",
+  "change_type": "Fix",
+  "summary": "Hide Next Up chores when any assigned category is marked as hidden in Up Next.",
+  "content_hash": "f6a63e6aaeea9ce2b4d5d61971472f2dcc27269238f36f8ea2fcb26050abd5a2"
+}

--- a/src/components/ChildSelector.tsx
+++ b/src/components/ChildSelector.tsx
@@ -210,7 +210,8 @@ export function ChildSelector({
             const childCategoryPoints = categoryPoints?.get(child.id)
             
             const choresMap = new Map(chores.map(c => [c.id, c]))
-            const nextChore = getNextUpcomingChore(child.id, assignments, choresMap, completions)
+            const categoriesMap = new Map(categories.map((category) => [category.id, category]))
+            const nextChore = getNextUpcomingChore(child.id, assignments, choresMap, completions, categoriesMap)
 
             return (
               <motion.div

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1035,7 +1035,8 @@ export function getNextUpcomingChore(
   childId: string,
   assignments: ChoreAssignment[],
   choresMap: Map<string, Chore>,
-  completions: ChoreCompletion[]
+  completions: ChoreCompletion[],
+  categoriesMap?: Map<string, Category>
 ): { chore: Chore; assignment: ChoreAssignment; timeOfDay?: 'am' | 'pm' } | null {
   const currentMinutes = getCurrentTimeInMinutes()
   const currentTimeOfDay = getCurrentTimeOfDay()
@@ -1048,6 +1049,7 @@ export function getNextUpcomingChore(
     .map((assignment) => {
       const chore = choresMap.get(assignment.choreId)
       if (!chore) return null
+      if (!shouldShowChoreInUpNext(chore, categoriesMap)) return null
 
       const effectiveTimeOfDay = assignment.timeOfDay || chore.timeOfDay || 'anytime'
       const effectiveTimeWindow = assignment.timeWindow || chore.timeWindow
@@ -1127,6 +1129,14 @@ export function getNextUpcomingChore(
     assignment: firstChore.assignment,
     timeOfDay: firstChore.timeOfDay,
   }
+}
+
+function shouldShowChoreInUpNext(chore: Chore, categoriesMap?: Map<string, Category>): boolean {
+  if (!categoriesMap || chore.categoryIds.length === 0) {
+    return true
+  }
+
+  return !chore.categoryIds.some((categoryId) => categoriesMap.get(categoryId)?.showInUpNext === false)
 }
 
 export function isRewardActive(reward: { startDate?: number; expiryDate?: number }): boolean {


### PR DESCRIPTION
### Motivation
- The Next Up card was showing chores that belong to categories with the "Show In Up Next" setting disabled, causing unexpected items to appear for children.
- The intent is to honor category visibility so only chores from categories allowed in Up Next are considered when selecting the next chore for a child.

### Description
- Update `getNextUpcomingChore` in `src/lib/helpers.ts` to accept an optional `categoriesMap` parameter and skip chores when any of their assigned categories have `showInUpNext === false`.
- Add a `shouldShowChoreInUpNext` helper function to encapsulate the visibility check logic in `src/lib/helpers.ts`.
- Pass a `categoriesMap` from `src/components/ChildSelector.tsx` into `getNextUpcomingChore` so the child selector respects category visibility when computing the next chore.
- Add a change log entry file at `changes/b72fbe02-504b-4f2e-866a-2d50b02084e0.json` documenting the fix.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to filtering logic and component integration and should be covered by existing unit/integration tests for `getNextUpcomingChore` and `ChildSelector` when added or run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697ea3828aa4832db0c03a4a72196f0c)