### PR TITLE
Add school holiday countdown card and display settings

### DIFF
--- a/changes/98a448f1-97b5-4a85-af85-1eb8f110c0b8.json
+++ b/changes/98a448f1-97b5-4a85-af85-1eb8f110c0b8.json
@@ -1,0 +1,7 @@
+{
+  "guid": "98a448f1-97b5-4a85-af85-1eb8f110c0b8",
+  "occurred_at": "2026-02-01T02:29:07.413991Z",
+  "change_type": "Feature",
+  "summary": "Add configurable school holiday countdown card on the main screen.",
+  "content_hash": "3553251b1e0183f5a248002a18dc3ce61e9b6a8476b4ae59ec0a9fcfadf409ff"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import {
   SpeechSettings,
   PushNotificationSettings,
   SchoolHoliday,
+  SchoolHolidayCountdownSettings,
 } from '@/lib/types'
 import { getChildTotalPoints, getChildAvailablePoints, canPurchaseReward, DEFAULT_CATEGORIES, getChildPointsByCategory, isRewardActive, getChildAvailablePointsByCategory, areAllCategoryChoresCompleted, hasBonusBeenClaimedToday, getUserIPAddress, isIPAllowed, isPrerequisiteCategoryCompleted } from '@/lib/helpers'
 import { DEFAULT_REPORT_TEMPLATES } from '@/lib/reportHelpers'
@@ -150,6 +151,11 @@ function App() {
     devices: [],
   })
   const [schoolHolidays, setSchoolHolidays] = useKV<SchoolHoliday[]>('school-holidays', [])
+  const [schoolHolidayCountdownSettings, setSchoolHolidayCountdownSettings] = useKV<SchoolHolidayCountdownSettings>('school-holiday-countdown-settings', {
+    enabled: false,
+    countdownMode: 'calendar-days',
+    showRemainingDays: true,
+  })
   const [hideChildrenWithNoActivity, setHideChildrenWithNoActivity] = useKV<boolean>('hide-children-with-no-activity', false)
   const normalizedParentPin = (() => {
     if (typeof parentPin !== 'string') {
@@ -1585,6 +1591,7 @@ Please log in to ChoreQuest to approve or reject this completion.
           currentDeviceId={getDeviceId()}
           hideChildrenWithNoActivity={hideChildrenWithNoActivity || false}
           schoolHolidays={schoolHolidays || []}
+          schoolHolidayCountdownSettings={schoolHolidayCountdownSettings || { enabled: false, countdownMode: 'calendar-days', showRemainingDays: true }}
           onAddChore={handleAddChore}
           onEditChore={handleEditChore}
           onDeleteChore={handleDeleteChore}
@@ -1625,6 +1632,7 @@ Please log in to ChoreQuest to approve or reject this completion.
           onAddSchoolHoliday={handleAddSchoolHoliday}
           onEditSchoolHoliday={handleEditSchoolHoliday}
           onDeleteSchoolHoliday={handleDeleteSchoolHoliday}
+          onUpdateSchoolHolidayCountdownSettings={(settings) => setSchoolHolidayCountdownSettings(settings)}
           onSendDigestNow={sendDigestEmail}
           onExitParentMode={() => {
             setMode('child')
@@ -1758,6 +1766,8 @@ Please log in to ChoreQuest to approve or reject this completion.
               speechSettings={speechSettings || { enabled: true }}
               biometricSettings={biometricSettings || { enabled: false, credentials: [], requirePinFallback: true, quickUnlockOnPWA: true }}
               hideChildrenWithNoActivity={hideChildrenWithNoActivity || false}
+              schoolHolidays={schoolHolidays || []}
+              schoolHolidayCountdownSettings={schoolHolidayCountdownSettings || { enabled: false, countdownMode: 'calendar-days', showRemainingDays: true }}
               onSelect={setSelectedChild}
               onParentMode={() => setShowPinDialog(true)}
             />

--- a/src/components/ChildSelector.tsx
+++ b/src/components/ChildSelector.tsx
@@ -6,9 +6,10 @@ import { Progress } from '@/components/ui/progress'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Gear, Trophy, Clock, SpeakerHigh, Fingerprint } from '@phosphor-icons/react'
-import { Child, GoalTracker, Reward, Category, ChoreAssignment, Chore, ChoreCompletion, WeatherSettings, SpeechSettings, BiometricSettings } from '@/lib/types'
+import { Child, GoalTracker, Reward, Category, ChoreAssignment, Chore, ChoreCompletion, WeatherSettings, SpeechSettings, BiometricSettings, SchoolHoliday, SchoolHolidayCountdownSettings } from '@/lib/types'
 import { getRewardCostForChild, getNextUpcomingChore, formatTime12Hour, formatDuration, getInitialsFromName, hasChildActivity } from '@/lib/helpers'
 import { WeatherDisplay } from '@/components/WeatherDisplay'
+import { SchoolHolidayCountdownCard } from '@/components/SchoolHolidayCountdownCard'
 import { isStandalone } from '@/lib/pwaHelper'
 import { fetchICSFeed, getICSEventsForToday } from '@/lib/icsHelper'
 
@@ -29,6 +30,8 @@ interface ChildSelectorProps {
   speechSettings?: SpeechSettings
   biometricSettings?: BiometricSettings
   hideChildrenWithNoActivity?: boolean
+  schoolHolidays?: SchoolHoliday[]
+  schoolHolidayCountdownSettings?: SchoolHolidayCountdownSettings
 }
 
 export function ChildSelector({ 
@@ -48,6 +51,8 @@ export function ChildSelector({
   speechSettings,
   biometricSettings,
   hideChildrenWithNoActivity = false,
+  schoolHolidays = [],
+  schoolHolidayCountdownSettings,
 }: ChildSelectorProps) {
   const [currentDateTime, setCurrentDateTime] = useState(new Date())
   const [isSpeaking, setIsSpeaking] = useState<string | null>(null)
@@ -187,14 +192,26 @@ export function ChildSelector({
           {formatDateTime(currentDateTime)}
         </motion.p>
 
-        {weatherSettings && (
+        {(weatherSettings || schoolHolidayCountdownSettings?.enabled) && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3 }}
-            className="mb-8 max-w-md mx-auto"
+            className="mb-8 flex flex-col items-center justify-center gap-4 md:flex-row"
           >
-            <WeatherDisplay settings={weatherSettings} />
+            {weatherSettings && (
+              <div className="w-full max-w-md">
+                <WeatherDisplay settings={weatherSettings} />
+              </div>
+            )}
+            {schoolHolidayCountdownSettings && (
+              <div className="w-full max-w-md">
+                <SchoolHolidayCountdownCard
+                  holidays={schoolHolidays}
+                  settings={schoolHolidayCountdownSettings}
+                />
+              </div>
+            )}
           </motion.div>
         )}
 

--- a/src/components/ParentPanel.tsx
+++ b/src/components/ParentPanel.tsx
@@ -19,7 +19,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import { Plus, Package, Check, ChartBar, Sparkle, Users, ListChecks, Gift, X, Gear, ClockCounterClockwise, Warning, ClipboardText, Shield, Envelope, FileText, SpeakerHigh, Bell } from '@phosphor-icons/react'
-import { Child, Chore, ChoreAssignment, Reward, RewardPurchase, ChoreCompletion, ChoreHistoryEvent, MissedChore, CelebrationSettings, Category, DayOfWeek, RepeatPattern, BiometricSettings, IPRestrictionSettings, IPAccessAttempt, WeeklyReportSettings, CategoryBonusCompletion, ReportTemplate, WeatherSettings, PointSwap, SMTPSettings, EmailAlertSettings, WeatherData, SpeechSettings, PushNotificationSettings, SchoolHoliday } from '@/lib/types'
+import { Child, Chore, ChoreAssignment, Reward, RewardPurchase, ChoreCompletion, ChoreHistoryEvent, MissedChore, CelebrationSettings, Category, DayOfWeek, RepeatPattern, BiometricSettings, IPRestrictionSettings, IPAccessAttempt, WeeklyReportSettings, CategoryBonusCompletion, ReportTemplate, WeatherSettings, PointSwap, SMTPSettings, EmailAlertSettings, WeatherData, SpeechSettings, PushNotificationSettings, SchoolHoliday, SchoolHolidayCountdownSettings } from '@/lib/types'
 import { choreTemplates, ChoreTemplate } from '@/lib/choreTemplates'
 import { ChoreCard } from './ChoreCard'
 import { ChildCard } from './ChildCard'
@@ -84,6 +84,7 @@ interface ParentPanelProps {
   currentDeviceId: string
   hideChildrenWithNoActivity: boolean
   schoolHolidays: SchoolHoliday[]
+  schoolHolidayCountdownSettings: SchoolHolidayCountdownSettings
   onAddChore: (chore: Omit<Chore, 'id' | 'createdAt'>) => void
   onEditChore: (id: string, chore: Omit<Chore, 'id' | 'createdAt'>) => void
   onDeleteChore: (id: string) => void
@@ -132,6 +133,7 @@ interface ParentPanelProps {
   onAddSchoolHoliday: (holiday: Omit<SchoolHoliday, 'id' | 'createdAt'>) => void
   onEditSchoolHoliday: (id: string, holiday: Omit<SchoolHoliday, 'id' | 'createdAt'>) => void
   onDeleteSchoolHoliday: (id: string) => void
+  onUpdateSchoolHolidayCountdownSettings: (settings: SchoolHolidayCountdownSettings) => void
   onSendDigestNow: () => void
   onExitParentMode: () => void
 }
@@ -205,9 +207,11 @@ export function ParentPanel({
   onEditReportTemplate,
   onDeleteReportTemplate,
   schoolHolidays,
+  schoolHolidayCountdownSettings,
   onAddSchoolHoliday,
   onEditSchoolHoliday,
   onDeleteSchoolHoliday,
+  onUpdateSchoolHolidayCountdownSettings,
   onSendDigestNow,
   onExitParentMode,
 }: ParentPanelProps) {
@@ -836,6 +840,8 @@ export function ParentPanel({
 
             <SchoolHolidaySettings
               holidays={schoolHolidays}
+              displaySettings={schoolHolidayCountdownSettings}
+              onUpdateDisplaySettings={onUpdateSchoolHolidayCountdownSettings}
               onAdd={onAddSchoolHoliday}
               onEdit={onEditSchoolHoliday}
               onDelete={onDeleteSchoolHoliday}

--- a/src/components/SchoolHolidayCountdownCard.tsx
+++ b/src/components/SchoolHolidayCountdownCard.tsx
@@ -1,0 +1,90 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { SchoolHoliday, SchoolHolidayCountdownSettings } from '@/lib/types'
+import { format } from 'date-fns'
+import { getActiveSchoolHoliday, getNextSchoolHoliday, getCalendarDaysUntil, getSchoolDaysUntil, getRemainingHolidayDays } from '@/lib/helpers'
+import { CalendarBlank } from '@phosphor-icons/react'
+
+interface SchoolHolidayCountdownCardProps {
+  holidays: SchoolHoliday[]
+  settings: SchoolHolidayCountdownSettings
+}
+
+export function SchoolHolidayCountdownCard({ holidays, settings }: SchoolHolidayCountdownCardProps) {
+  if (!settings.enabled) {
+    return null
+  }
+
+  const today = new Date()
+  const activeHoliday = getActiveSchoolHoliday(today, holidays)
+
+  if (activeHoliday) {
+    const remainingDays = getRemainingHolidayDays(today, activeHoliday)
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <CalendarBlank className="h-5 w-5 text-primary" />
+            {activeHoliday.name} is on
+          </CardTitle>
+          <CardDescription>
+            {format(new Date(activeHoliday.startDate), 'MMM d, yyyy')} -{' '}
+            {format(new Date(activeHoliday.endDate), 'MMM d, yyyy')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {settings.showRemainingDays ? (
+            <p className="text-2xl font-fredoka text-accent">
+              {remainingDays} {remainingDays === 1 ? 'day' : 'days'} remaining
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">Enjoy the break!</p>
+          )}
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const nextHoliday = getNextSchoolHoliday(today, holidays)
+  if (!nextHoliday) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <CalendarBlank className="h-5 w-5 text-primary" />
+            School Holidays
+          </CardTitle>
+          <CardDescription>No upcoming holidays yet</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">Add holiday dates in settings.</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const countdown = settings.countdownMode === 'school-days'
+    ? getSchoolDaysUntil(today, new Date(nextHoliday.startDate))
+    : getCalendarDaysUntil(today, new Date(nextHoliday.startDate))
+
+  const countdownLabel = settings.countdownMode === 'school-days' ? 'School days' : 'Days'
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <CalendarBlank className="h-5 w-5 text-primary" />
+          {nextHoliday.name} is coming up
+        </CardTitle>
+        <CardDescription>
+          {format(new Date(nextHoliday.startDate), 'MMM d, yyyy')} -{' '}
+          {format(new Date(nextHoliday.endDate), 'MMM d, yyyy')}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-fredoka text-accent">
+          {countdown} {countdownLabel} until break
+        </p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/SchoolHolidaySettings.tsx
+++ b/src/components/SchoolHolidaySettings.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Dialog,
   DialogContent,
@@ -11,7 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { SchoolHoliday } from '@/lib/types'
+import { SchoolHoliday, SchoolHolidayCountdownSettings, SchoolHolidayCountdownMode } from '@/lib/types'
 import { format } from 'date-fns'
 import { toast } from 'sonner'
 import { Plus, Trash, CalendarBlank, PencilSimple } from '@phosphor-icons/react'
@@ -21,12 +23,21 @@ import { Info } from '@phosphor-icons/react'
 
 interface SchoolHolidaySettingsProps {
   holidays: SchoolHoliday[]
+  displaySettings: SchoolHolidayCountdownSettings
+  onUpdateDisplaySettings: (settings: SchoolHolidayCountdownSettings) => void
   onAdd: (holiday: Omit<SchoolHoliday, 'id' | 'createdAt'>) => void
   onEdit: (id: string, holiday: Omit<SchoolHoliday, 'id' | 'createdAt'>) => void
   onDelete: (id: string) => void
 }
 
-export function SchoolHolidaySettings({ holidays, onAdd, onEdit, onDelete }: SchoolHolidaySettingsProps) {
+export function SchoolHolidaySettings({
+  holidays,
+  displaySettings,
+  onUpdateDisplaySettings,
+  onAdd,
+  onEdit,
+  onDelete,
+}: SchoolHolidaySettingsProps) {
   const [showDialog, setShowDialog] = useState(false)
   const [editingHoliday, setEditingHoliday] = useState<SchoolHoliday | null>(null)
   const [name, setName] = useState('')
@@ -187,6 +198,70 @@ export function SchoolHolidaySettings({ holidays, onAdd, onEdit, onDelete }: Sch
               })}
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <CalendarBlank className="h-5 w-5" />
+            School Holiday Countdown
+          </CardTitle>
+          <CardDescription>
+            Show a holiday countdown card on the main screen
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label>Enable Countdown</Label>
+              <p className="text-sm text-muted-foreground">
+                Display the school holiday countdown next to the weather
+              </p>
+            </div>
+            <Switch
+              checked={displaySettings.enabled}
+              onCheckedChange={(enabled) => onUpdateDisplaySettings({ ...displaySettings, enabled })}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="holiday-countdown-mode">Countdown Type</Label>
+            <Select
+              value={displaySettings.countdownMode}
+              onValueChange={(value) =>
+                onUpdateDisplaySettings({
+                  ...displaySettings,
+                  countdownMode: value as SchoolHolidayCountdownMode,
+                })
+              }
+              disabled={!displaySettings.enabled}
+            >
+              <SelectTrigger id="holiday-countdown-mode">
+                <SelectValue placeholder="Select countdown type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="calendar-days">Calendar days until holidays</SelectItem>
+                <SelectItem value="school-days">School days until holidays</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label>Show Remaining Days During Holidays</Label>
+              <p className="text-sm text-muted-foreground">
+                Display how many holiday days are left when school is out
+              </p>
+            </div>
+            <Switch
+              checked={displaySettings.showRemainingDays}
+              onCheckedChange={(showRemainingDays) =>
+                onUpdateDisplaySettings({ ...displaySettings, showRemainingDays })
+              }
+              disabled={!displaySettings.enabled}
+            />
+          </div>
         </CardContent>
       </Card>
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -118,6 +118,78 @@ export function isDateOnSchoolHoliday(date: Date, schoolHolidays: SchoolHoliday[
   })
 }
 
+export function getActiveSchoolHoliday(date: Date, schoolHolidays: SchoolHoliday[]): SchoolHoliday | null {
+  const checkDate = new Date(date)
+  checkDate.setHours(0, 0, 0, 0)
+  const checkTime = checkDate.getTime()
+
+  return (
+    schoolHolidays.find((holiday) => {
+      const startOfDay = new Date(holiday.startDate)
+      startOfDay.setHours(0, 0, 0, 0)
+      const endOfDay = new Date(holiday.endDate)
+      endOfDay.setHours(23, 59, 59, 999)
+      return checkTime >= startOfDay.getTime() && checkTime <= endOfDay.getTime()
+    }) || null
+  )
+}
+
+export function getNextSchoolHoliday(date: Date, schoolHolidays: SchoolHoliday[]): SchoolHoliday | null {
+  const checkDate = new Date(date)
+  checkDate.setHours(0, 0, 0, 0)
+  const checkTime = checkDate.getTime()
+
+  const upcoming = schoolHolidays
+    .filter((holiday) => holiday.startDate > checkTime)
+    .sort((a, b) => a.startDate - b.startDate)
+
+  return upcoming[0] || null
+}
+
+export function getCalendarDaysUntil(date: Date, targetDate: Date): number {
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+  const target = new Date(targetDate)
+  target.setHours(0, 0, 0, 0)
+  const diff = target.getTime() - start.getTime()
+  return Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)))
+}
+
+export function getSchoolDaysUntil(date: Date, targetDate: Date): number {
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+  const target = new Date(targetDate)
+  target.setHours(0, 0, 0, 0)
+
+  let count = 0
+  const cursor = new Date(start)
+  cursor.setDate(cursor.getDate() + 1)
+
+  while (cursor.getTime() < target.getTime()) {
+    const day = cursor.getDay()
+    if (day !== 0 && day !== 6) {
+      count += 1
+    }
+    cursor.setDate(cursor.getDate() + 1)
+  }
+
+  return count
+}
+
+export function getRemainingHolidayDays(date: Date, holiday: SchoolHoliday): number {
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+  const end = new Date(holiday.endDate)
+  end.setHours(0, 0, 0, 0)
+
+  if (end.getTime() < start.getTime()) {
+    return 0
+  }
+
+  const diff = end.getTime() - start.getTime()
+  return Math.floor(diff / (1000 * 60 * 60 * 24)) + 1
+}
+
 export function isChoreActiveOnDate(assignment: ChoreAssignment, date: Date): boolean {
   if (!isRepeatPatternActiveOnDate(assignment, date)) {
     return false

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,6 +95,14 @@ export interface SchoolHoliday {
   createdAt: number
 }
 
+export type SchoolHolidayCountdownMode = 'calendar-days' | 'school-days'
+
+export interface SchoolHolidayCountdownSettings {
+  enabled: boolean
+  countdownMode: SchoolHolidayCountdownMode
+  showRemainingDays: boolean
+}
+
 export interface Chore {
   id: string
   name: string


### PR DESCRIPTION
### Motivation
- Provide an optional school-holidays countdown card on the main screen next to the weather that can count either calendar days or school days, and optionally show remaining holiday days while a holiday is active.

### Description
- Add new types `SchoolHolidayCountdownMode` and `SchoolHolidayCountdownSettings` in `src/lib/types.ts` to persist countdown configuration. 
- Implement helper utilities in `src/lib/helpers.ts` (`getActiveSchoolHoliday`, `getNextSchoolHoliday`, `getCalendarDaysUntil`, `getSchoolDaysUntil`, `getRemainingHolidayDays`) to determine active/upcoming holidays and compute countdown values. 
- Add a presentational `SchoolHolidayCountdownCard` component in `src/components/SchoolHolidayCountdownCard.tsx` to render the countdown or remaining days and format holiday ranges. 
- Extend `SchoolHolidaySettings` (`src/components/SchoolHolidaySettings.tsx`) with UI controls (enable toggle, countdown type select, show-remaining-days toggle) for configuring the card. 
- Wire settings and rendering through the app: store countdown settings in KV (`src/App.tsx`), expose them via `ParentPanel` props, and render the countdown card next to the weather in `ChildSelector` when enabled. 
- Create a change-log entry for this feature in `changes/` (JSON file) for the app change tracking system.

### Testing
- Launched the dev server with `npm run dev` which started Vite successfully (server reachable locally). 
- Ran a Playwright script to exercise adding a holiday, enable the countdown and capture a screenshot; the script completed and produced `artifacts/school-holiday-countdown.png`. 
- Ran `npm run lint` which failed due to a missing ESLint config (`eslint.config.*`), so automated lint checks did not pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697eb98df488832d9cebbfe53b216540)