### PR TITLE
Add emoji support for school holidays and equalize Weather/Holiday card heights

### DIFF
--- a/changes/11a6f373-359c-4949-9c24-463651fe3ab0.json
+++ b/changes/11a6f373-359c-4949-9c24-463651fe3ab0.json
@@ -1,0 +1,7 @@
+{
+  "guid": "11a6f373-359c-4949-9c24-463651fe3ab0",
+  "occurred_at": "2026-02-01T02:52:04.859708Z",
+  "change_type": "Feature",
+  "summary": "Add emoji support for school holiday entries and align weather/holiday card heights.",
+  "content_hash": "fc33596f0915ba270d1707f8db75ae47e8f151e64f31516ec42add190f8adf56"
+}

--- a/src/components/ChildSelector.tsx
+++ b/src/components/ChildSelector.tsx
@@ -199,15 +199,15 @@ export function ChildSelector({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3 }}
-            className="mb-8 flex flex-col items-center justify-center gap-4 md:flex-row"
+            className="mb-8 flex flex-col items-center justify-center gap-4 md:flex-row md:items-stretch"
           >
             {weatherSettings && (
-              <div className="w-full max-w-md">
+              <div className="flex w-full max-w-md">
                 <WeatherDisplay settings={weatherSettings} />
               </div>
             )}
             {schoolHolidayCountdownSettings && (
-              <div className="w-full max-w-md">
+              <div className="flex w-full max-w-md">
                 <SchoolHolidayCountdownCard
                   holidays={schoolHolidays}
                   settings={schoolHolidayCountdownSettings}

--- a/src/components/SchoolHolidayCountdownCard.tsx
+++ b/src/components/SchoolHolidayCountdownCard.tsx
@@ -19,11 +19,13 @@ export function SchoolHolidayCountdownCard({ holidays, settings }: SchoolHoliday
 
   if (activeHoliday) {
     const remainingDays = getRemainingHolidayDays(today, activeHoliday)
+    const activeEmoji = activeHoliday.emoji?.trim()
     return (
-      <Card>
+      <Card className="h-full">
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-lg">
             <CalendarBlank className="h-5 w-5 text-primary" />
+            {activeEmoji && <span className="text-xl" aria-hidden="true">{activeEmoji}</span>}
             {activeHoliday.name} is on
           </CardTitle>
           <CardDescription>
@@ -47,7 +49,7 @@ export function SchoolHolidayCountdownCard({ holidays, settings }: SchoolHoliday
   const nextHoliday = getNextSchoolHoliday(today, holidays)
   if (!nextHoliday) {
     return (
-      <Card>
+      <Card className="h-full">
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-lg">
             <CalendarBlank className="h-5 w-5 text-primary" />
@@ -68,11 +70,13 @@ export function SchoolHolidayCountdownCard({ holidays, settings }: SchoolHoliday
 
   const countdownLabel = settings.countdownMode === 'school-days' ? 'School days' : 'Days'
 
+  const nextEmoji = nextHoliday.emoji?.trim()
   return (
-    <Card>
+    <Card className="h-full">
       <CardHeader className="pb-2">
         <CardTitle className="flex items-center gap-2 text-lg">
           <CalendarBlank className="h-5 w-5 text-primary" />
+          {nextEmoji && <span className="text-xl" aria-hidden="true">{nextEmoji}</span>}
           {nextHoliday.name} is coming up
         </CardTitle>
         <CardDescription>

--- a/src/components/SchoolHolidaySettings.tsx
+++ b/src/components/SchoolHolidaySettings.tsx
@@ -41,6 +41,7 @@ export function SchoolHolidaySettings({
   const [showDialog, setShowDialog] = useState(false)
   const [editingHoliday, setEditingHoliday] = useState<SchoolHoliday | null>(null)
   const [name, setName] = useState('')
+  const [emoji, setEmoji] = useState('')
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
 
@@ -48,11 +49,13 @@ export function SchoolHolidaySettings({
     if (holiday) {
       setEditingHoliday(holiday)
       setName(holiday.name)
+      setEmoji(holiday.emoji ?? '')
       setStartDate(format(new Date(holiday.startDate), 'yyyy-MM-dd'))
       setEndDate(format(new Date(holiday.endDate), 'yyyy-MM-dd'))
     } else {
       setEditingHoliday(null)
       setName('')
+      setEmoji('')
       setStartDate('')
       setEndDate('')
     }
@@ -80,6 +83,7 @@ export function SchoolHolidaySettings({
 
     const holidayData = {
       name: name.trim(),
+      emoji: emoji.trim() ? emoji.trim() : undefined,
       startDate: start.getTime(),
       endDate: end.getTime(),
     }
@@ -92,6 +96,7 @@ export function SchoolHolidaySettings({
 
     setShowDialog(false)
     setName('')
+    setEmoji('')
     setStartDate('')
     setEndDate('')
     setEditingHoliday(null)
@@ -153,6 +158,9 @@ export function SchoolHolidaySettings({
                       <div className="flex items-start justify-between gap-4">
                         <div className="flex-1">
                           <div className="flex items-center gap-2 mb-2">
+                            {holiday.emoji && (
+                              <span className="text-xl" aria-hidden="true">{holiday.emoji}</span>
+                            )}
                             <h3 className="font-semibold">{holiday.name}</h3>
                             {isCurrent && (
                               <Badge variant="default" className="text-xs">
@@ -279,6 +287,18 @@ export function SchoolHolidaySettings({
           </DialogHeader>
 
           <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="holiday-emoji">Holiday Emoji (optional)</Label>
+              <Input
+                id="holiday-emoji"
+                value={emoji}
+                onChange={(e) => setEmoji(e.target.value)}
+                placeholder="🎉"
+                maxLength={8}
+                className="text-2xl text-center"
+              />
+            </div>
+
             <div className="space-y-2">
               <Label htmlFor="holiday-name">Holiday Name</Label>
               <Input

--- a/src/components/WeatherDisplay.tsx
+++ b/src/components/WeatherDisplay.tsx
@@ -41,7 +41,7 @@ export function WeatherDisplay({ settings }: WeatherDisplayProps) {
 
   if (loading) {
     return (
-      <Card className="p-3 bg-gradient-to-br from-sky-50 to-blue-50">
+      <Card className="h-full p-3 bg-gradient-to-br from-sky-50 to-blue-50">
         <div className="text-center text-sm text-muted-foreground">
           Loading weather...
         </div>
@@ -54,7 +54,7 @@ export function WeatherDisplay({ settings }: WeatherDisplayProps) {
   const unitSymbol = weather.unit === 'celsius' ? 'C' : 'F'
 
   return (
-    <Card className="p-4 bg-gradient-to-br from-sky-50 to-blue-50 border-sky-200">
+    <Card className="h-full p-4 bg-gradient-to-br from-sky-50 to-blue-50 border-sky-200">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="text-4xl">{weatherEmoji}</div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -90,6 +90,7 @@ export interface WeatherConditionRequirement {
 export interface SchoolHoliday {
   id: string
   name: string
+  emoji?: string
   startDate: number
   endDate: number
   createdAt: number


### PR DESCRIPTION
### Motivation
- Improve the holiday user experience by allowing an optional emoji for each school holiday and surface it in the settings and countdown UI. 
- Make the Weather and Holiday cards visually consistent by matching their heights when displayed side-by-side on the main child selector screen.

### Description
- Added an optional `emoji?: string` field to the `SchoolHoliday` type in `src/lib/types.ts` to persist emoji values. 
- Updated `src/components/SchoolHolidaySettings.tsx` to accept an optional holiday emoji in the add/edit dialog and to show the emoji in the holiday list. 
- Updated `src/components/SchoolHolidayCountdownCard.tsx` to render the holiday emoji (when present) and applied `className="h-full"` to cards so heights match. 
- Updated `src/components/WeatherDisplay.tsx` to apply `className="h-full"` to the card wrappers and adjusted `src/components/ChildSelector.tsx` layout to `md:items-stretch` with `flex` wrappers so the two cards align vertically.
- Added a changelog entry at `changes/11a6f373-359c-4949-9c24-463651fe3ab0.json` describing the feature.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served at the local URL, which completed successfully. 
- Captured a visual verification screenshot by launching a headless Playwright script and saving `artifacts/weather-holiday-cards.png`, which completed successfully and shows the Weather and Holiday cards aligned. 
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697ebf566a14832dbddbfd8316101dda)