### PR TITLE
Install Docker CLI in API container to enable in-app updates

### DIFF
--- a/changes/d31fab15-10de-413d-9672-073f68fe429c.json
+++ b/changes/d31fab15-10de-413d-9672-073f68fe429c.json
@@ -1,0 +1,7 @@
+{
+  "guid": "d31fab15-10de-413d-9672-073f68fe429c",
+  "occurred_at": "2026-02-01T07:26:14.384766Z",
+  "change_type": "Fix",
+  "summary": "Install Docker CLI in the API container so dashboard-triggered updates can run.",
+  "content_hash": "e8b25d66b5dbea6b51573b7ed00e713033eca94fd8acc4ed96aa2642aa461f1c"
+}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,6 +16,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
+RUN apk add --no-cache docker-cli docker-cli-compose
+
 COPY package*.json ./
 
 RUN npm ci --only=production


### PR DESCRIPTION
### Motivation
- The in-app update flow detects new releases but cannot perform the upgrade when triggered from the dashboard because the API container lacked the Docker CLI/Compose binaries required by the internal update script.

### Description
- Install the Docker CLI and Compose in the production API image by adding `RUN apk add --no-cache docker-cli docker-cli-compose` to `server/Dockerfile` so `scripts/update-internal.sh` can run when the container has the Docker socket mounted.
- Add a changelog entry at `changes/d31fab15-10de-413d-9672-073f68fe429c.json` documenting this fix.

### Testing
- No automated tests were run against the modified code; the change was validated by inspecting the updated `server/Dockerfile` and creating/committing the changelog file (`git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697eff7e2848832dbe614659a6a5aaa9)