### PR TITLE
Fix update flow to refresh cached assets

### DIFF
--- a/changes/c932da8c-fe2a-4884-aee3-296bc6967d39.json
+++ b/changes/c932da8c-fe2a-4884-aee3-296bc6967d39.json
@@ -1,0 +1,7 @@
+{
+  "guid": "c932da8c-fe2a-4884-aee3-296bc6967d39",
+  "occurred_at": "2026-02-01T08:08:54.514239Z",
+  "change_type": "Fix",
+  "summary": "Clear service worker and cache storage after update to ensure the latest version loads.",
+  "content_hash": "554d6b17e77a5c582bf68f576a4af943d99219bea144c84d5f8130fd043b747c"
+}

--- a/src/components/UpdateSettings.tsx
+++ b/src/components/UpdateSettings.tsx
@@ -53,6 +53,26 @@ export function UpdateSettings() {
   const [checkError, setCheckError] = useState<string | null>(null)
   const [showUpdateDialog, setShowUpdateDialog] = useState(false)
 
+  const clearCachesAndReload = async () => {
+    try {
+      if ('serviceWorker' in navigator) {
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(registrations.map((registration) => registration.unregister()))
+      }
+
+      if ('caches' in window) {
+        const cacheNames = await caches.keys()
+        await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)))
+      }
+    } catch (error) {
+      console.warn('Failed to clear caches after update:', error)
+    } finally {
+      const url = new URL(window.location.href)
+      url.searchParams.set('updated', Date.now().toString())
+      window.location.replace(url.toString())
+    }
+  }
+
   const checkForUpdates = async () => {
     setIsChecking(true)
     setCheckError(null)
@@ -128,7 +148,7 @@ export function UpdateSettings() {
         // Reload the page after a delay to get the new version
         // Use a longer timeout to allow the update to complete
         setTimeout(() => {
-          window.location.reload()
+          void clearCachesAndReload()
         }, 20000)
       } else {
         throw new Error(result.message || 'Update failed')


### PR DESCRIPTION
### Motivation
- Users reported the UI still showing the old version after the server-side update because cached assets and a registered service worker prevented the client from loading the new build.

### Description
- Add `clearCachesAndReload` to `src/components/UpdateSettings.tsx` to unregister service workers, delete cache storage, and perform a cache-busting reload using a query parameter.
- Replace the previous `window.location.reload()` call with `clearCachesAndReload()` after a successful update trigger to ensure the newest assets are fetched.
- Add a changelog entry `changes/c932da8c-fe2a-4884-aee3-296bc6967d39.json` documenting the fix.

### Testing
- Ran `npm run lint` which failed due to missing ESLint v9 configuration (`eslint.config.*`), so lint errors remain and no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697f0955a128832d901ed972808881e7)