### PR TITLE
Fix crash on Devices settings when API returns no list

### DIFF
--- a/src/lib/deviceHelper.ts
+++ b/src/lib/deviceHelper.ts
@@ -147,7 +147,7 @@ export const getLinkedDevices = async (token: string): Promise<Array<{
   }
 
   const data = await response.json();
-  return data.devices;
+  return Array.isArray(data.devices) ? data.devices : [];
 };
 
 /**
@@ -204,4 +204,3 @@ export const unlinkDevice = async (token: string, deviceId: string): Promise<voi
     throw new Error(error.error || 'Failed to unlink device');
   }
 };
-


### PR DESCRIPTION
### Motivation
- The Settings > Devices page could crash with `Cannot read properties of undefined (reading 'length')` when the backend response omitted the `devices` list, so the client needs a safe fallback.

### Description
- Updated `getLinkedDevices` in `src/lib/deviceHelper.ts` to return `Array.isArray(data.devices) ? data.devices : []`, guarding against missing or malformed `devices` in the API response.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981940153fc833299723338c39828e3)