### PR TITLE
Fix device management date parsing for linked devices

### DIFF
--- a/src/components/DeviceManagement.tsx
+++ b/src/components/DeviceManagement.tsx
@@ -54,9 +54,9 @@ interface DeviceInfoExtended {
   deviceName: string | null;
   deviceInfo: DeviceInfo;
   allowedChildrenIds: string[];
-  linkedAt: Date;
-  lastSeen: Date;
-  createdAt: Date;
+  linkedAt: Date | null;
+  lastSeen: Date | null;
+  createdAt: Date | null;
 }
 
 export function DeviceManagement() {
@@ -82,13 +82,26 @@ export function DeviceManagement() {
     }
   }, [token]);
 
+  const parseDate = (value: string | Date | null): Date | null => {
+    if (!value) return null;
+    const parsed = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  };
+
   const loadDevices = async () => {
     if (!token) return;
     
     setLoading(true);
     try {
       const linkedDevices = await getLinkedDevices(token);
-      setDevices(linkedDevices);
+      setDevices(
+        linkedDevices.map((device) => ({
+          ...device,
+          linkedAt: parseDate(device.linkedAt),
+          lastSeen: parseDate(device.lastSeen),
+          createdAt: parseDate(device.createdAt),
+        }))
+      );
     } catch (error) {
       console.error('Error loading devices:', error);
       toast.error('Failed to load devices');
@@ -230,7 +243,8 @@ export function DeviceManagement() {
     return `${browser} on ${os}`;
   };
 
-  const formatLastSeen = (date: Date) => {
+  const formatLastSeen = (date: Date | null) => {
+    if (!date) return 'Never';
     const now = new Date();
     const lastSeen = new Date(date);
     const diffMs = now.getTime() - lastSeen.getTime();
@@ -322,7 +336,7 @@ export function DeviceManagement() {
                       </p>
                     )}
                     <p className="text-xs text-muted-foreground mt-0.5">
-                      Linked: {new Date(device.linkedAt).toLocaleString()}
+                      Linked: {device.linkedAt ? device.linkedAt.toLocaleString() : 'Unknown'}
                     </p>
                     
                     {/* Display allowed children */}


### PR DESCRIPTION
### Motivation
- A TypeScript build error occurred because device timestamp fields coming from the API could be `string | null` but the UI expected `Date`, causing `TS2345` when setting state.

### Description
- Change `DeviceInfoExtended` date fields to `Date | null` in `src/components/DeviceManagement.tsx`.
- Add a `parseDate` helper to normalize `string | Date | null` values into `Date | null` before storing in state.
- Normalize the results of `getLinkedDevices` in `loadDevices` by mapping and parsing `linkedAt`, `lastSeen`, and `createdAt` prior to `setDevices`.
- Make `formatLastSeen` accept `Date | null` and return a safe label (`"Never"`) for missing values, and show `"Unknown"` for missing `linkedAt` when rendering.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698198991dc8833283d4053aeb4ef470)