### PR TITLE
Improve service worker cache refresh for new releases

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -32,7 +32,8 @@ async function initializeCacheVersion() {
 const CACHE_EXCLUDE_PATTERNS = [
   '/_spark/',
   '/api/',
-  '/health'
+  '/health',
+  '/version.json'
 ];
 
 // Check if a URL should be excluded from caching
@@ -92,9 +93,25 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   const requestUrl = event.request.url;
+  const request = event.request;
   
   // Don't intercept requests to external origins
   if (!requestUrl.startsWith(self.location.origin)) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put('/index.html', responseClone);
+          });
+          return response;
+        })
+        .catch(() => caches.match('/index.html'))
+    );
     return;
   }
   
@@ -104,17 +121,17 @@ self.addEventListener('fetch', (event) => {
   }
 
   event.respondWith(
-    caches.match(event.request).then((cachedResponse) => {
+    caches.match(request).then((cachedResponse) => {
       if (cachedResponse) {
         return cachedResponse;
       }
 
       return caches.open(RUNTIME_CACHE).then((cache) => {
-        return fetch(event.request)
+        return fetch(request)
           .then((response) => {
             // Only cache successful responses
             if (response.status === 200) {
-              cache.put(event.request, response.clone());
+              cache.put(request, response.clone());
             }
             return response;
           })


### PR DESCRIPTION
### Motivation
- Prevent users from seeing stale UI after upgrades by ensuring version checks always hit the network and the app shell is refreshed when a new release is deployed.

### Description
- Exclude `'/version.json'` from caching by adding it to `CACHE_EXCLUDE_PATTERNS` so version checks always go to the network.
- Switch navigation requests (`request.mode === 'navigate'`) to a network-first strategy that updates the cached app shell by fetching and writing `/index.html` to the current `CACHE_NAME` on success.
- Consolidate use of the request object by introducing `const request = event.request` and replace uses of `event.request` with `request` for clarity and consistency.
- Use the `request` key when storing runtime responses in the cache (`cache.put(request, response.clone())`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69819c06ab2483329d997595809262af)