### PR TITLE
Fix reward chore requirement toggling to prevent React update error

### DIFF
--- a/changes/e7eb8b8e-6bf6-4f4a-ab2f-13e2e0552c43.json
+++ b/changes/e7eb8b8e-6bf6-4f4a-ab2f-13e2e0552c43.json
@@ -1,0 +1,7 @@
+{
+  "guid": "e7eb8b8e-6bf6-4f4a-ab2f-13e2e0552c43",
+  "occurred_at": "2026-02-03T09:18:16.126768Z",
+  "change_type": "Fix",
+  "summary": "Fix reward chore requirement toggling to avoid update loops",
+  "content_hash": "cb6d7945058a59a24e10911ec420ad5dbfdf3d1e7c205db5eb91fae3cb074eea"
+}

--- a/src/components/RewardDialog.tsx
+++ b/src/components/RewardDialog.tsx
@@ -54,6 +54,8 @@ export function RewardDialog({ reward, onSave, trigger, childrenList = [], chore
   const [swapFromAmount, setSwapFromAmount] = useState(reward?.swapConfig?.fromAmount?.toString() || '')
   const [swapToAmount, setSwapToAmount] = useState(reward?.swapConfig?.toAmount?.toString() || '')
 
+  const normalizeRequiredChoreIds = (ids?: string[]) => (Array.isArray(ids) ? ids : [])
+
   useEffect(() => {
     if (open) {
       if (reward) {
@@ -65,7 +67,12 @@ export function RewardDialog({ reward, onSave, trigger, childrenList = [], chore
         const rewardCategoryIds = reward.categoryIds || []
         setCategoryIds(Array.isArray(rewardCategoryIds) ? [...rewardCategoryIds] : [])
         setCostOverrides(reward.costOverrides || [])
-        setRequirements(reward.requirements || [])
+        setRequirements(
+          (reward.requirements || []).map((requirement) => ({
+            childId: requirement.childId,
+            requiredChoreIds: normalizeRequiredChoreIds(requirement.requiredChoreIds),
+          }))
+        )
         setHasLimit(!!reward.purchaseLimit)
         setLimitMax(reward.purchaseLimit?.maxPurchases?.toString() || '1')
         setLimitInterval(reward.purchaseLimit?.interval || 'day')
@@ -174,28 +181,38 @@ export function RewardDialog({ reward, onSave, trigger, childrenList = [], chore
     setOpen(false)
   }
 
-  const toggleChoreRequirement = (childId: string, choreId: string) => {
+  const updateChoreRequirement = (childId: string, choreId: string, shouldRequire: boolean) => {
     setRequirements(current => {
       const childReq = current.find(r => r.childId === childId)
-      if (!childReq) {
+      const requiredChoreIds = normalizeRequiredChoreIds(childReq?.requiredChoreIds)
+
+      if (shouldRequire && !childReq) {
         return [...current, { childId, requiredChoreIds: [choreId] }]
       }
       
-      if (childReq.requiredChoreIds.includes(choreId)) {
-        const updated = childReq.requiredChoreIds.filter(id => id !== choreId)
+      if (!childReq) {
+        return current
+      }
+
+      if (!shouldRequire && requiredChoreIds.includes(choreId)) {
+        const updated = requiredChoreIds.filter(id => id !== choreId)
         if (updated.length === 0) {
           return current.filter(r => r.childId !== childId)
         }
         return current.map(r => 
           r.childId === childId ? { ...r, requiredChoreIds: updated } : r
         )
-      } else {
-        return current.map(r => 
-          r.childId === childId 
-            ? { ...r, requiredChoreIds: [...r.requiredChoreIds, choreId] } 
+      }
+
+      if (shouldRequire && !requiredChoreIds.includes(choreId)) {
+        return current.map(r =>
+          r.childId === childId
+            ? { ...r, requiredChoreIds: [...requiredChoreIds, choreId] }
             : r
         )
       }
+
+      return current
     })
   }
 
@@ -633,7 +650,8 @@ export function RewardDialog({ reward, onSave, trigger, childrenList = [], chore
                       <div className="space-y-4">
                         {childrenList.map((child) => {
                           const childReq = requirements.find(r => r.childId === child.id)
-                          const hasRequirements = childReq && childReq.requiredChoreIds.length > 0
+                          const requiredChoreIds = normalizeRequiredChoreIds(childReq?.requiredChoreIds)
+                          const hasRequirements = requiredChoreIds.length > 0
 
                           return (
                             <Card key={child.id} className="p-3">
@@ -649,26 +667,34 @@ export function RewardDialog({ reward, onSave, trigger, childrenList = [], chore
                                     <span className="font-medium">{child.name}</span>
                                     {hasRequirements && (
                                       <p className="text-xs text-muted-foreground">
-                                        {childReq.requiredChoreIds.length} chore(s) required
+                                        {requiredChoreIds.length} chore(s) required
                                       </p>
                                     )}
                                   </div>
                                 </div>
                                 {chores.length > 0 && (
                                   <div className="pl-11 space-y-1">
-                                    {chores.slice(0, 5).map((chore) => (
-                                      <div
-                                        key={chore.id}
-                                        className="flex items-center gap-2 cursor-pointer hover:bg-accent p-1 rounded"
-                                        onClick={() => toggleChoreRequirement(child.id, chore.id)}
-                                      >
-                                        <Checkbox 
-                                          checked={childReq?.requiredChoreIds.includes(chore.id) || false}
-                                          onCheckedChange={() => toggleChoreRequirement(child.id, chore.id)}
-                                        />
-                                        <span className="text-sm">{chore.name}</span>
-                                      </div>
-                                    ))}
+                                    {chores.slice(0, 5).map((chore) => {
+                                      const checkboxId = `reward-req-${child.id}-${chore.id}`
+                                      const isChecked = requiredChoreIds.includes(chore.id)
+                                      return (
+                                        <div
+                                          key={chore.id}
+                                          className="flex items-center gap-2 hover:bg-accent p-1 rounded"
+                                        >
+                                          <Checkbox
+                                            id={checkboxId}
+                                            checked={isChecked}
+                                            onCheckedChange={(checked) => {
+                                              updateChoreRequirement(child.id, chore.id, checked === true)
+                                            }}
+                                          />
+                                          <label htmlFor={checkboxId} className="text-sm cursor-pointer">
+                                            {chore.name}
+                                          </label>
+                                        </div>
+                                      )
+                                    })}
                                     {chores.length > 5 && (
                                       <p className="text-xs text-muted-foreground pl-6">
                                         +{chores.length - 5} more chores available


### PR DESCRIPTION
### Motivation
- Prevent a React update loop / invariant triggered when editing reward chore requirements by ensuring requirement arrays are normalized and checkbox state updates are explicit. 

### Description
- Normalize reward requirement arrays when loading an existing reward by mapping `reward.requirements` to ensure `requiredChoreIds` is always an array in `src/components/RewardDialog.tsx`.
- Replace the previous toggling helper with `updateChoreRequirement(childId, choreId, shouldRequire)` which updates requirements based on an explicit checked boolean instead of inferring intent from toggles. 
- Render labeled checkboxes with stable `id`s and wire `onCheckedChange` to the new updater to avoid uncontrolled/ambiguous state transitions in the dialog UI. 
- Add a changelog entry at `changes/e7eb8b8e-6bf6-4f4a-ab2f-13e2e0552c43.json` documenting the fix.

### Testing
- No automated tests were run for this change (no CI/test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981bc70264c832d8e8ec02f152a272f)