### PR TITLE
Make view-only tenant banner span full width

### DIFF
--- a/src/components/ViewOnlyBanner.tsx
+++ b/src/components/ViewOnlyBanner.tsx
@@ -17,7 +17,7 @@ export function ViewOnlyBanner({ tenantId, onExit }: ViewOnlyBannerProps) {
   }
 
   return (
-    <Alert className="rounded-none border-x-0 border-t-0 bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800 py-2">
+    <Alert className="rounded-none border-x-0 border-t-0 bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800 py-2 grid-cols-1">
       <div className="flex items-center justify-between w-full gap-4">
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <Eye className="h-4 w-4 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />


### PR DESCRIPTION
### Motivation
- The Viewing tenant banner was consolidating to the left instead of spanning the available width, so make the alert use a single grid column so it can stretch across the screen.

### Description
- Add `grid-cols-1` to the `Alert` class in `src/components/ViewOnlyBanner.tsx` so the banner layout uses a single grid column and can fill the horizontal space.

### Testing
- Started the dev server with `npm run dev` which reported Vite ready (succeeded), and attempted an automated Playwright screenshot which failed because Chromium crashed in the container (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982ad9941ec8332a466a091d7275a04)