### PR TITLE
Restore admin auth when exiting view-only tenant mode

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -368,6 +368,10 @@ export function AdminPanel() {
       
       const data = await response.json()
       
+      // Store the current admin token so we can restore it on exit
+      if (token) {
+        localStorage.setItem('admin_auth_token', token)
+      }
       // Store the view token and redirect to the main app
       localStorage.setItem('auth_token', data.token)
       localStorage.setItem('view_only_mode', 'true')

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -190,6 +190,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setViewOnlyMode(false);
     setViewingTenantId(null);
     localStorage.removeItem('auth_token');
+    localStorage.removeItem('admin_auth_token');
     localStorage.removeItem('view_only_mode');
     localStorage.removeItem('viewing_tenant_id');
   };
@@ -198,9 +199,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Clear view-only mode and navigate back to admin panel
     setViewOnlyMode(false);
     setViewingTenantId(null);
+    const adminToken = localStorage.getItem('admin_auth_token');
+    if (adminToken) {
+      setToken(adminToken);
+      localStorage.setItem('auth_token', adminToken);
+      fetchUserInfo(adminToken);
+      localStorage.removeItem('admin_auth_token');
+    } else {
+      setToken(null);
+      setUser(null);
+      localStorage.removeItem('auth_token');
+    }
     localStorage.removeItem('view_only_mode');
     localStorage.removeItem('viewing_tenant_id');
-    // Note: Token remains for admin user, just exit view mode
+    // Note: Admin token is restored when exiting view mode
   };
 
   const inviteParent = async (email: string) => {


### PR DESCRIPTION
### Motivation
- Exiting tenant view-only mode required a manual refresh because the admin's auth token was overwritten by the tenant view token, preventing automatic restoration of the admin session.

### Description
- In `AdminPanel.viewTenant` the current admin token is saved to `localStorage` under `admin_auth_token` before replacing `auth_token` with the tenant view token.
- In `AuthContext.exitViewMode` the code now reads `admin_auth_token` and, if present, restores it by calling `setToken`, writing `auth_token` back to `localStorage`, and invoking `fetchUserInfo`, then removes the temporary `admin_auth_token` key.
- The `logout` path was updated to remove `admin_auth_token` to avoid leaving a stale token in storage.
- A comment was updated to reflect that the admin token is restored when exiting view mode.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982aeb17114833292e9298eb0b7156d)