### PR TITLE
Enforce plan limits on KV writes (children, chores, rewards)

### DIFF
--- a/server/src/routes/kv.ts
+++ b/server/src/routes/kv.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { pool } from '../config/database.js';
 import type { RowDataPacket } from 'mysql2';
 import { optionalAuth, AuthRequest } from '../middleware/auth.js';
+import { checkPlanLimits } from '../services/subscription.js';
 
 const router = Router();
 
@@ -12,6 +13,8 @@ const ARRAY_KEYS = [
   'chore-history', 'dismissed-missed-chores', 'tracked-goals', 'categories',
   'point-swaps', 'bonus-completions', 'child-availability'
 ];
+const PLAN_LIMIT_KEYS = ['children', 'chores', 'rewards'] as const;
+type PlanLimitKey = (typeof PLAN_LIMIT_KEYS)[number];
 
 /**
  * Check if the request is from Spark runtime (@github/spark useKV hook).
@@ -35,6 +38,24 @@ function sendNullResponse(req: Request, res: Response): void {
   } else {
     res.json({ value: null });
   }
+}
+
+function getPlanLimitForKey(
+  key: PlanLimitKey,
+  limits: Awaited<ReturnType<typeof checkPlanLimits>>
+): number | null {
+  switch (key) {
+    case 'children':
+      return limits.limits.maxChildren;
+    case 'chores':
+      return limits.limits.maxChores;
+    case 'rewards':
+      return limits.limits.maxRewards;
+  }
+}
+
+function isPlanLimitedKey(key: string): key is PlanLimitKey {
+  return PLAN_LIMIT_KEYS.includes(key as PlanLimitKey);
 }
 
 // Get a value by key
@@ -135,6 +156,18 @@ router.post('/:key', optionalAuth, async (req: AuthRequest, res: Response) => {
         error: `Key "${key}" must be an array`,
         received: typeof value 
       });
+    }
+
+    if (isPlanLimitedKey(key)) {
+      const limits = await checkPlanLimits(tenantId);
+      const maxLimit = getPlanLimitForKey(key, limits);
+      if (maxLimit !== null && Array.isArray(value) && value.length > maxLimit) {
+        return res.status(403).json({
+          error: `Plan limit reached for ${key}`,
+          limit: maxLimit,
+          attempted: value.length,
+        });
+      }
     }
     
     await pool.query(
@@ -242,6 +275,22 @@ router.post('/', optionalAuth, async (req: AuthRequest, res: Response) => {
       });
     }
     
+    const limitKeys = Object.keys(data).filter(isPlanLimitedKey);
+    if (limitKeys.length > 0) {
+      const limits = await checkPlanLimits(tenantId);
+      for (const key of limitKeys) {
+        const maxLimit = getPlanLimitForKey(key, limits);
+        const value = data[key];
+        if (maxLimit !== null && Array.isArray(value) && value.length > maxLimit) {
+          return res.status(403).json({
+            error: `Plan limit reached for ${key}`,
+            limit: maxLimit,
+            attempted: value.length,
+          });
+        }
+      }
+    }
+
     const connection = await pool.getConnection();
     try {
       await connection.beginTransaction();


### PR DESCRIPTION
### Motivation
- Prevent parents from adding more Children, Chores, or Rewards than their subscription plan allows by blocking KV writes that would exceed plan limits.
- Apply the same protection to bulk/migration KV updates to avoid accidental over-limit imports.

### Description
- Imported `checkPlanLimits` from `server/src/services/subscription.ts` and added `PLAN_LIMIT_KEYS` for `children`, `chores`, and `rewards` to centralize which KV keys are limit-checked.
- Added helper functions `getPlanLimitForKey` and `isPlanLimitedKey` to map keys to plan limits and identify keys that require checks.
- For single-key writes (`POST /:key`) the route now checks the tenant's plan limits and returns `403` with `limit` and `attempted` details if the write would exceed the allowed count; existing array-key validation remains.
- For bulk writes (`POST /`) the route now pre-checks any present plan-limited keys and rejects the whole request with `403` if any provided array exceeds the plan limit before performing the DB transaction.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982b0002bcc8332b0b51c4a25c8bbc8)