### PR TITLE
Improve auth error messaging for KV saves

### DIFF
--- a/src/hooks/use-api-kv.ts
+++ b/src/hooks/use-api-kv.ts
@@ -69,6 +69,13 @@ interface QueuedRequest {
   reject: (error: Error) => void;
 }
 
+class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
 const requestQueue: QueuedRequest[] = [];
 let activeRequests = 0;
 const MAX_CONCURRENT_REQUESTS = 5; // Limit concurrent requests to avoid overwhelming the server
@@ -303,6 +310,9 @@ export function useApiKV<T>(key: string, defaultValue: T): [T, (value: T | ((pre
           });
           
           if (!response.ok) {
+            if (response.status === 401 || response.status === 403) {
+              throw new AuthError('Your session has expired or you are not signed in. Please sign in again to save changes.');
+            }
             throw new Error('Failed to save to API');
           }
         });
@@ -311,11 +321,17 @@ export function useApiKV<T>(key: string, defaultValue: T): [T, (value: T | ((pre
         // Fallback to localStorage to ensure data is not lost
         try {
           localStorage.setItem(key, JSON.stringify(computedValue));
-          // Display user-friendly error message after successful localStorage save
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-          toast.error('Failed to save data to server', {
-            description: `Unable to save to server: ${errorMessage}. Data saved locally as backup.`
-          });
+          if (error instanceof AuthError) {
+            toast.error('Please sign in again', {
+              description: error.message
+            });
+          } else {
+            // Display user-friendly error message after successful localStorage save
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            toast.error('Failed to save data to server', {
+              description: `Unable to save to server: ${errorMessage}. Data saved locally as backup.`
+            });
+          }
         } catch (localStorageError) {
           console.error('Error saving to localStorage fallback:', localStorageError);
           // Both API and localStorage failed - show more severe error


### PR DESCRIPTION
### Motivation

- Provide clearer, actionable error messaging when KV saves fail due to authentication issues (401/403) so users are prompted to re-authenticate instead of seeing a generic save failure.

### Description

- Add an `AuthError` class to represent auth-specific failures in the KV save flow in `src/hooks/use-api-kv.ts`.
- Detect `401`/`403` responses when saving to the API and throw `AuthError` with a re-sign-in message.
- Show a focused sign-in toast (`Please sign in again`) for `AuthError` cases while preserving the existing localStorage fallback and generic error toast for non-auth failures.
- Keep existing queueing, local fallback, and broader error handling behavior intact.

### Testing

- Started the dev server with `npm run dev` and verified Vite reported a ready server (`Local: http://localhost:5000/`).
- Captured a screenshot of the login page using a Playwright script which produced `artifacts/login-page.png` (screenshot step succeeded).
- No unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982b2e075048332906944248c984574)