### PR TITLE
Fix subscription API paths and reduce KV auth noise

### DIFF
--- a/src/hooks/use-api-kv.ts
+++ b/src/hooks/use-api-kv.ts
@@ -107,6 +107,11 @@ function queueRequest(execute: () => Promise<void>): Promise<void> {
 // Check if API is available
 async function checkApiAvailability(forceRefresh = false): Promise<boolean> {
   const now = Date.now();
+  const token = getAuthToken();
+
+  if (!token) {
+    return false;
+  }
   
   // If API was previously determined to be available, trust that result
   if (apiAvailable === true) {
@@ -183,6 +188,10 @@ function validateLoadedValue<T>(loadedValue: any, defaultValue: T): T {
   return defaultValue;
 }
 
+function isAuthFailure(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
 export function useApiKV<T>(key: string, defaultValue: T): [T, (value: T | ((prevValue: T) => T)) => Promise<void>] {
   const [value, setValue] = useState<T>(defaultValue);
   const [useApi, setUseApi] = useState<boolean>(false);
@@ -231,6 +240,23 @@ export function useApiKV<T>(key: string, defaultValue: T): [T, (value: T | ((pre
               if (mounted) {
                 // validateLoadedValue handles null values by returning defaultValue
                 setValue(validateLoadedValue(data.value, defaultValueRef.current));
+              }
+            } else if (isAuthFailure(response.status)) {
+              apiAvailable = false;
+              apiCheckTimestamp = Date.now();
+              if (mounted) {
+                setUseApi(false);
+                const stored = localStorage.getItem(key);
+                if (stored) {
+                  try {
+                    const parsedValue = JSON.parse(stored);
+                    setValue(validateLoadedValue(parsedValue, defaultValueRef.current));
+                  } catch {
+                    setValue(defaultValueRef.current);
+                  }
+                } else {
+                  setValue(defaultValueRef.current);
+                }
               }
             } else if (response.status === 404) {
               // Legacy: Key not found (older API versions returned 404)
@@ -303,6 +329,13 @@ export function useApiKV<T>(key: string, defaultValue: T): [T, (value: T | ((pre
           });
           
           if (!response.ok) {
+            if (isAuthFailure(response.status)) {
+              apiAvailable = false;
+              apiCheckTimestamp = Date.now();
+              setUseApi(false);
+              localStorage.setItem(key, JSON.stringify(computedValue));
+              return;
+            }
             throw new Error('Failed to save to API');
           }
         });

--- a/src/hooks/use-subscription.ts
+++ b/src/hooks/use-subscription.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Subscription, SubscriptionPlan, Invoice, UsageStats } from '@/lib/types';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = import.meta.env.VITE_API_URL || '/api';
 
 interface PlanLimitsResponse {
   canAddChild: boolean;
@@ -37,7 +37,7 @@ export function useSubscription() {
     if (!token) return;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/plans`, {
+      const response = await fetch(`${API_URL}/subscriptions/plans`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -61,7 +61,7 @@ export function useSubscription() {
 
     try {
       setLoading(true);
-      const response = await fetch(`${API_URL}/api/subscriptions/current`, {
+      const response = await fetch(`${API_URL}/subscriptions/current`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -86,7 +86,7 @@ export function useSubscription() {
     if (!token) return;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/limits`, {
+      const response = await fetch(`${API_URL}/subscriptions/limits`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -109,7 +109,7 @@ export function useSubscription() {
     if (!token) return;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/invoices`, {
+      const response = await fetch(`${API_URL}/subscriptions/invoices`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -132,7 +132,7 @@ export function useSubscription() {
     if (!token) return null;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/create-setup-intent`, {
+      const response = await fetch(`${API_URL}/subscriptions/create-setup-intent`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -157,7 +157,7 @@ export function useSubscription() {
     if (!token) return false;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/create`, {
+      const response = await fetch(`${API_URL}/subscriptions/create`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -186,7 +186,7 @@ export function useSubscription() {
     if (!token) return false;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/cancel`, {
+      const response = await fetch(`${API_URL}/subscriptions/cancel`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -213,7 +213,7 @@ export function useSubscription() {
     if (!token) return false;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/reactivate`, {
+      const response = await fetch(`${API_URL}/subscriptions/reactivate`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -240,7 +240,7 @@ export function useSubscription() {
     if (!token) return false;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/update-quantity`, {
+      const response = await fetch(`${API_URL}/subscriptions/update-quantity`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -268,7 +268,7 @@ export function useSubscription() {
     if (!token) return false;
 
     try {
-      const response = await fetch(`${API_URL}/api/subscriptions/downgrade`, {
+      const response = await fetch(`${API_URL}/subscriptions/downgrade`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import { ErrorBoundary } from "react-error-boundary";
 import { BrowserRouter } from 'react-router-dom'
-import "@github/spark/spark"
 
 import App from './App.tsx'
 import { ErrorFallback } from './ErrorFallback.tsx'
@@ -10,6 +9,10 @@ import { AuthProvider } from './contexts/AuthContext.tsx'
 import "./main.css"
 import "./styles/theme.css"
 import "./index.css"
+
+if (import.meta.env.VITE_SPARK_ENABLED === 'true') {
+  void import('@github/spark/spark')
+}
 
 createRoot(document.getElementById('root')!).render(
   <ErrorBoundary FallbackComponent={ErrorFallback}>


### PR DESCRIPTION
### Motivation
- Subscription requests were generating 404/403 errors due to duplicated or incorrect API paths and an incorrect default base URL, and KV API calls were producing noisy 401/403 console errors when no auth token was present.
- Spark was always imported which caused network requests to `/_spark/` even when Spark features were not enabled.

### Description
- Updated `src/hooks/use-subscription.ts` to set `API_URL` default to `/api` and to call endpoints under `${API_URL}/subscriptions/...` (removed an extra `/api` segment) to fix 404s when viewing subscription details.
- Improved `src/hooks/use-api-kv.ts` to avoid attempting API health or KV calls when there is no auth token, added `isAuthFailure` detection for 401/403 responses, mark the API as unavailable on auth failures, and gracefully fall back to `localStorage` (including saving a local copy on save failures) to reduce console noise and prevent repeated failed requests.
- Made Spark initialization conditional in `src/main.tsx` so `@github/spark/spark` is only imported when `VITE_SPARK_ENABLED` is set to `true`, preventing unnecessary `/_spark/` requests when Spark is disabled.
- Files changed: `src/hooks/use-subscription.ts`, `src/hooks/use-api-kv.ts`, `src/main.tsx`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982b0d2600c83328d64851df43d5c17)