### PR TITLE
Reset API availability on auth token changes

### DIFF
--- a/src/hooks/use-api-kv.ts
+++ b/src/hooks/use-api-kv.ts
@@ -11,8 +11,19 @@ const API_URL = import.meta.env.VITE_API_URL || '/api';
 // Event emitter for auth token changes
 const authTokenListeners = new Set<() => void>();
 
+// Track if API is available
+let apiAvailable: boolean | null = null;
+let apiCheckTimestamp: number | null = null;
+const API_RECHECK_INTERVAL_MS = 30000; // Recheck API availability every 30 seconds if it was previously unavailable
+
+function resetApiAvailability() {
+  apiAvailable = null;
+  apiCheckTimestamp = null;
+}
+
 // Notify all listeners when auth token changes
 function notifyAuthTokenChange() {
+  resetApiAvailability();
   authTokenListeners.forEach(listener => listener());
 }
 
@@ -56,11 +67,6 @@ localStorage.removeItem = function(key: string) {
     setTimeout(() => notifyAuthTokenChange(), 0);
   }
 };
-
-// Track if API is available
-let apiAvailable: boolean | null = null;
-let apiCheckTimestamp: number | null = null;
-const API_RECHECK_INTERVAL_MS = 30000; // Recheck API availability every 30 seconds if it was previously unavailable
 
 // Request queue to throttle concurrent API requests
 interface QueuedRequest {


### PR DESCRIPTION
### Motivation
- Exiting view-only/admin view mode did not always trigger a fresh `/auth/me` check so the app could remain pointed at the wrong tenant until a manual refresh; the cached API availability should be cleared when the auth token changes.

### Description
- In `src/hooks/use-api-kv.ts` introduce `apiAvailable`, `apiCheckTimestamp`, and `resetApiAvailability()` and call the reset from `notifyAuthTokenChange()` so a token change forces a fresh API availability check.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982c2a4b2a48332ba8395600f1f44ac)