### PR TITLE
Fix Stripe subscription payment confirmation (return client secret & confirm payment)

### DIFF
--- a/src/components/SubscriptionSettings.tsx
+++ b/src/components/SubscriptionSettings.tsx
@@ -70,17 +70,27 @@ function PaymentForm({ plan, childrenCount, onSuccess }: {
       }
 
       // Create subscription
-      const success = await createPaidSubscription(
+      const subscriptionResult = await createPaidSubscription(
         setupIntent.payment_method as string,
         childrenCount
       );
 
-      if (success) {
-        toast.success('Subscription activated successfully!');
-        onSuccess();
-      } else {
+      if (!subscriptionResult) {
         throw new Error('Failed to activate subscription');
       }
+
+      if (subscriptionResult.clientSecret) {
+        const { error: paymentError } = await stripe.confirmCardPayment(
+          subscriptionResult.clientSecret
+        );
+
+        if (paymentError) {
+          throw new Error(paymentError.message);
+        }
+      }
+
+      toast.success('Subscription activated successfully!');
+      onSuccess();
     } catch (err: any) {
       setError(err.message || 'Payment failed');
       toast.error(err.message || 'Payment failed');

--- a/src/hooks/use-subscription.ts
+++ b/src/hooks/use-subscription.ts
@@ -209,8 +209,8 @@ export function useSubscription() {
   }, [token]);
 
   // Create paid subscription
-  const createPaidSubscription = useCallback(async (paymentMethodId: string, childrenCount: number): Promise<boolean> => {
-    if (!token) return false;
+  const createPaidSubscription = useCallback(async (paymentMethodId: string, childrenCount: number): Promise<{ clientSecret?: string } | null> => {
+    if (!token) return null;
 
     try {
       const response = await fetch(`${API_URL}/subscriptions/create`, {
@@ -227,13 +227,14 @@ export function useSubscription() {
         throw new Error(errorData.error || 'Failed to create subscription');
       }
 
+      const result = await response.json();
       await fetchSubscription();
       await fetchLimits();
-      return true;
+      return result;
     } catch (err: any) {
       console.error('Error creating subscription:', err);
       setError(err.message);
-      return false;
+      return null;
     }
   }, [token, fetchSubscription, fetchLimits]);
 


### PR DESCRIPTION
### Motivation

- Subscriptions were remaining in an "incomplete" state because the Stripe payment intent returned from subscription creation was not being confirmed client-side. 
- The frontend needs the payment intent client secret to confirm the initial invoice payment so Stripe can transition the subscription out of `incomplete`/`past_due` states.

### Description

- Updated the subscription helper in `src/hooks/use-subscription.ts` to return the subscription creation response (including an optional `clientSecret`) instead of a simple boolean and to propagate backend response JSON. 
- Updated the payment flow in `src/components/SubscriptionSettings.tsx` to consume the returned `clientSecret` and call `stripe.confirmCardPayment` when present, and to surface payment errors to the user. 
- Adjusted error handling so failures from the subscription creation or payment confirmation are reported to the UI and logging. 
- Files changed: `src/hooks/use-subscription.ts` and `src/components/SubscriptionSettings.tsx`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982d8a550f0833285052a62b8e3c80a)