### PR TITLE
Prorate Stripe subscription on decreases and sync child count updates

### DIFF
--- a/server/src/routes/subscriptions.ts
+++ b/server/src/routes/subscriptions.ts
@@ -157,7 +157,7 @@ router.post('/update-quantity', authenticateToken, async (req: AuthRequest, res:
     
     const { childrenCount } = req.body;
     
-    if (!childrenCount || childrenCount < 1) {
+    if (childrenCount === undefined || childrenCount === null || childrenCount < 0) {
       return res.status(400).json({ error: 'Invalid children count' });
     }
     

--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -448,8 +448,13 @@ export async function updateSubscriptionQuantity(tenantId: string, childrenCount
   
   // Update the quantity of the first item
   if (stripeSubscription.items.data.length > 0) {
+    const currentQuantity = stripeSubscription.items.data[0].quantity ?? 0;
+    if (currentQuantity === childrenCount) {
+      return;
+    }
     await stripe.subscriptionItems.update(stripeSubscription.items.data[0].id, {
       quantity: childrenCount,
+      proration_behavior: 'create_prorations',
     });
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { AdminPanel } from '@/components/AdminPanel'
 import { ViewOnlyBanner } from '@/components/ViewOnlyBanner'
 import { initializePWA } from '@/lib/pwaHelper'
 import { getDeviceId, registerDevice, getDeviceGuid, getLinkedDevices } from '@/lib/deviceHelper'
+import { useSubscription } from '@/hooks/use-subscription'
 import {
   AppMode,
   Child,
@@ -73,6 +74,7 @@ function App() {
   const location = useLocation()
   const navigate = useNavigate()
   const { user, token, loading: authLoading, logout, loginWithDevice, getTenantUsers, viewOnlyMode, viewingTenantId, exitViewMode } = useAuth()
+  const { updateQuantity } = useSubscription()
   
   // Handle accept-invitation route (doesn't require authentication)
   if (location.pathname === '/accept-invitation') {
@@ -702,6 +704,7 @@ function App() {
       createdAt: Date.now(),
     }
     setChildrenList((current) => [...(current || []), newChild])
+    void updateQuantity((childrenList || []).length + 1)
     toast.success(`${newChild.name} added!`)
   })
 
@@ -723,6 +726,8 @@ function App() {
     setCompletions((current) => (current || []).filter((c) => c.childId !== id))
     setChildAvailability((current) => (current || []).filter((entry) => entry.childId !== id))
     
+    const nextCount = Math.max((childrenList || []).length - 1, 0)
+    void updateQuantity(nextCount)
     toast.success('Child removed')
   })
 

--- a/src/components/ChildDialog.tsx
+++ b/src/components/ChildDialog.tsx
@@ -18,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { useSubscription } from '@/hooks/use-subscription'
 import { Child, CalendarRefreshInterval } from '@/lib/types'
 import { AVATAR_COLORS } from '@/lib/helpers'
 
@@ -29,6 +30,7 @@ interface ChildDialogProps {
 }
 
 export function ChildDialog({ open, onOpenChange, onSave, editChild }: ChildDialogProps) {
+  const { subscription } = useSubscription()
   const [name, setName] = useState(editChild?.name || '')
   const [avatarColor, setAvatarColor] = useState(
     editChild?.avatarColor || AVATAR_COLORS[0]
@@ -43,6 +45,8 @@ export function ChildDialog({ open, onOpenChange, onSave, editChild }: ChildDial
   const [calendarShowTimes, setCalendarShowTimes] = useState(
     editChild?.calendarShowTimes ?? true
   )
+  const pricePerChildAUD = subscription?.plan?.pricePerChildAUD ?? 0
+  const showBillingWarning = !editChild && subscription?.plan?.tier === 'paid'
 
   useEffect(() => {
     if (open) {
@@ -86,6 +90,14 @@ export function ChildDialog({ open, onOpenChange, onSave, editChild }: ChildDial
           <DialogDescription>Add a child to your family chore tracker</DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
+          {showBillingWarning && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+              Adding a child will increase your subscription by {pricePerChildAUD > 0
+                ? `$${pricePerChildAUD.toFixed(2)} AUD per child`
+                : 'the per-child rate'}.
+              {' '}The additional charge will be prorated on your next billing cycle.
+            </div>
+          )}
           <div className="grid gap-2">
             <Label htmlFor="child-name">Child's Name</Label>
             <Input

--- a/src/components/ParentPanel.tsx
+++ b/src/components/ParentPanel.tsx
@@ -1303,8 +1303,9 @@ export function ParentPanel({
           <AlertDialogHeader>
             <AlertDialogTitle>Delete Child</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to delete this child? This will remove all their assignments
-              and completion history.
+              Are you sure you want to delete this child? This will remove the child immediately,
+              including all history. Your subscription fee will be reduced at the end of the
+              current billing cycle.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
### Motivation
- Ensure Stripe subscription updates always create prorations so decreases in per-child quantity can be prorated like increases.
- Keep the app and Stripe in sync by updating subscription quantity when children are added or removed in the UI.
- Surface billing impact to parents when adding a child and make deletion behaviour explicit in the confirmation dialog.

### Description
- Always set `proration_behavior: 'create_prorations'` when updating the subscription item quantity in `server/src/services/subscription.ts`, and short-circuit when the quantity is unchanged to make the update idempotent.
- Relax API validation in `server/src/routes/subscriptions.ts` to accept zero children by changing the request check to `childrenCount === undefined || childrenCount === null || childrenCount < 0`.
- Import and call `updateQuantity` from `useSubscription` in `src/App.tsx` when adding (`handleAddChild`) and removing (`handleDeleteChild`) children so the backend receives the new count.
- Add a billing warning to `src/components/ChildDialog.tsx` that shows per-child pricing and mentions proration when adding a child, and update the delete-child confirmation text in `src/components/ParentPanel.tsx` to state the child is removed immediately and billing reduces at period end.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982d9cb5d508332891766657d311a78)