### PR TITLE
Fix subscription cancellation date display and persist Stripe period end

### DIFF
--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -396,19 +396,30 @@ export async function cancelSubscription(tenantId: string): Promise<void> {
   if (!subscription) {
     throw new Error('No subscription found');
   }
-  
+  let updatedPeriodEnd: number | null = null;
+
   // Cancel Stripe subscription if exists
   if (stripe && subscription.stripe_subscription_id) {
-    await stripe.subscriptions.update(subscription.stripe_subscription_id, {
+    const updatedSubscription = await stripe.subscriptions.update(subscription.stripe_subscription_id, {
       cancel_at_period_end: true,
     });
+    if (updatedSubscription.current_period_end) {
+      updatedPeriodEnd = updatedSubscription.current_period_end * 1000;
+    }
   }
   
   // Update database
-  await pool.query<ResultSetHeader>(
-    'UPDATE subscriptions SET cancel_at_period_end = TRUE WHERE tenant_id = ?',
-    [tenantId]
-  );
+  if (updatedPeriodEnd) {
+    await pool.query<ResultSetHeader>(
+      'UPDATE subscriptions SET cancel_at_period_end = TRUE, current_period_end = ? WHERE tenant_id = ?',
+      [updatedPeriodEnd, tenantId]
+    );
+  } else {
+    await pool.query<ResultSetHeader>(
+      'UPDATE subscriptions SET cancel_at_period_end = TRUE WHERE tenant_id = ?',
+      [tenantId]
+    );
+  }
 }
 
 /**

--- a/src/components/SubscriptionSettings.tsx
+++ b/src/components/SubscriptionSettings.tsx
@@ -350,8 +350,19 @@ export function SubscriptionSettings({ childrenCount }: SubscriptionSettingsProp
               <Alert>
                 <Warning className="h-4 w-4" />
                 <AlertDescription>
-                  Your subscription will be canceled on {new Date(subscription.currentPeriodEnd).toLocaleDateString()}.
-                  You can reactivate it at any time before then.
+                  {subscription.currentPeriodEnd && !Number.isNaN(new Date(subscription.currentPeriodEnd).getTime())
+                    ? (
+                      <>
+                        Your subscription will be canceled on {new Date(subscription.currentPeriodEnd).toLocaleDateString()}.
+                        You can reactivate it at any time before then.
+                      </>
+                    )
+                    : (
+                      <>
+                        Your subscription is set to cancel at the end of the current billing period.
+                        You can reactivate it at any time before then.
+                      </>
+                    )}
                 </AlertDescription>
               </Alert>
             )}


### PR DESCRIPTION
### Motivation
- Users saw an invalid epoch date (e.g. 01/01/1970) when cancelling because the stored period end could be missing or invalid, so the UI must avoid rendering invalid dates. 
- When cancelling a Stripe subscription the backend should refresh and persist Stripe's `current_period_end` so the stored end date remains accurate.

### Description
- Backend: updated `cancelSubscription` to use the Stripe response (`stripe.subscriptions.update`) and capture `current_period_end`, converting it to ms and persisting it to the `subscriptions.current_period_end` column when available. 
- Frontend: updated `SubscriptionSettings` to guard the cancellation alert copy by checking `subscription.currentPeriodEnd` and `Number.isNaN(new Date(...).getTime())`, showing a fallback message when the date is missing/invalid instead of attempting to format it.

### Testing
- Started the dev server with `npm run dev` (Vite reported ready) and exercised the UI; a Playwright-driven screenshot of the running app landing page was captured successfully. 
- No unit or integration test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982dd7d92688332b5e96ef749910d0d)