### PR TITLE
Route subscription flows through Stripe Checkout/Billing Portal and add webhook sync

### DIFF
--- a/server/src/routes/subscriptions.ts
+++ b/server/src/routes/subscriptions.ts
@@ -12,7 +12,10 @@ import {
   getTenantInvoices,
   checkPlanLimits,
   getOrCreateStripeCustomer,
+  syncSubscriptionByStripeId,
   stripe,
+  upsertInvoiceFromStripe,
+  upsertSubscriptionFromStripe,
 } from '../services/subscription.js';
 
 const router = Router();
@@ -209,6 +212,112 @@ router.get('/invoices', authenticateToken, async (req: AuthRequest, res: Respons
 });
 
 /**
+ * POST /api/subscriptions/checkout-session
+ * Create a Stripe Checkout session for starting a paid subscription
+ * Body: { childrenCount: number }
+ */
+router.post('/checkout-session', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    if (!stripe) {
+      return res.status(503).json({ error: 'Stripe is not configured' });
+    }
+
+    const tenantId = req.tenantId;
+    const email = req.userEmail;
+
+    if (!tenantId || !email) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const { childrenCount } = req.body;
+
+    if (!childrenCount || childrenCount < 1) {
+      return res.status(400).json({ error: 'Must have at least 1 child' });
+    }
+
+    const customerId = await getOrCreateStripeCustomer(tenantId, email);
+    const plans = await getSubscriptionPlansForTenant(tenantId);
+    const paidPlan = plans.find((plan) => plan.tier === 'paid');
+
+    if (!paidPlan) {
+      return res.status(404).json({ error: 'Paid plan not found' });
+    }
+
+    const unitAmount = Math.round((Number(paidPlan.price_per_child_aud) || 0) * 100);
+    if (unitAmount <= 0) {
+      return res.status(400).json({ error: 'Paid plan price is not configured' });
+    }
+
+    const price = await stripe.prices.create({
+      currency: 'aud',
+      unit_amount: unitAmount,
+      recurring: {
+        interval: 'month',
+      },
+      product_data: {
+        name: 'ChoreQuest Paid Subscription',
+      },
+    });
+
+    const appUrl = process.env.APP_URL || 'http://localhost:5000';
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: customerId,
+      line_items: [
+        {
+          price: price.id,
+          quantity: childrenCount,
+        },
+      ],
+      success_url: `${appUrl}/?checkout=success`,
+      cancel_url: `${appUrl}/?checkout=cancel`,
+      subscription_data: {
+        metadata: {
+          tenant_id: tenantId,
+          children_count: childrenCount.toString(),
+        },
+      },
+    });
+
+    res.json({ url: session.url });
+  } catch (error: any) {
+    console.error('Error creating checkout session:', error);
+    res.status(500).json({ error: error.message || 'Failed to create checkout session' });
+  }
+});
+
+/**
+ * POST /api/subscriptions/billing-portal
+ * Create a Stripe Billing Portal session for managing subscription changes
+ */
+router.post('/billing-portal', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    if (!stripe) {
+      return res.status(503).json({ error: 'Stripe is not configured' });
+    }
+
+    const tenantId = req.tenantId;
+    const email = req.userEmail;
+
+    if (!tenantId || !email) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const customerId = await getOrCreateStripeCustomer(tenantId, email);
+    const appUrl = process.env.APP_URL || 'http://localhost:5000';
+    const session = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${appUrl}/?portal=return`,
+    });
+
+    res.json({ url: session.url });
+  } catch (error: any) {
+    console.error('Error creating billing portal session:', error);
+    res.status(500).json({ error: error.message || 'Failed to create billing portal session' });
+  }
+});
+
+/**
  * POST /api/subscriptions/create-setup-intent
  * Create a Stripe SetupIntent for saving payment method
  */
@@ -275,28 +384,34 @@ router.post('/webhook', async (req: Request, res: Response) => {
     switch (event.type) {
       case 'customer.subscription.updated':
       case 'customer.subscription.deleted': {
-        // Type assertion for webhook event data
         const subscription = event.data.object as any;
-        // Update subscription status in database
-        // TODO: Implement subscription status update
+        await upsertSubscriptionFromStripe(subscription);
         console.log('Subscription event:', event.type, subscription.id);
         break;
       }
-      
+
       case 'invoice.paid': {
-        // Type assertion for webhook event data
         const invoice = event.data.object as any;
-        // Record successful payment
-        // TODO: Implement invoice recording
+        await upsertInvoiceFromStripe(invoice);
+        if (invoice.subscription) {
+          const stripeSubscriptionId = typeof invoice.subscription === 'string'
+            ? invoice.subscription
+            : invoice.subscription.id;
+          await syncSubscriptionByStripeId(stripeSubscriptionId);
+        }
         console.log('Invoice paid:', invoice.id);
         break;
       }
-      
+
       case 'invoice.payment_failed': {
-        // Type assertion for webhook event data
         const failedInvoice = event.data.object as any;
-        // Handle failed payment - move to limited mode
-        // TODO: Implement payment failure handling
+        await upsertInvoiceFromStripe(failedInvoice);
+        if (failedInvoice.subscription) {
+          const stripeSubscriptionId = typeof failedInvoice.subscription === 'string'
+            ? failedInvoice.subscription
+            : failedInvoice.subscription.id;
+          await syncSubscriptionByStripeId(stripeSubscriptionId);
+        }
         console.log('Invoice payment failed:', failedInvoice.id);
         break;
       }

--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -14,6 +14,8 @@ export const stripe = stripeSecretKey ? new Stripe(stripeSecretKey, {
   apiVersion: '2026-01-28.clover',
 }) : null;
 
+type SubscriptionStatus = 'active' | 'past_due' | 'canceled' | 'incomplete' | 'incomplete_expired' | 'trialing' | 'unpaid';
+
 // Subscription Plan Interfaces
 export interface SubscriptionPlan {
   id: string;
@@ -434,6 +436,125 @@ export async function createPaidSubscription(
   };
 }
 
+async function getSubscriptionRowByStripeId(stripeSubscriptionId: string): Promise<{ id: string; tenant_id: string } | null> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT id, tenant_id FROM subscriptions WHERE stripe_subscription_id = ? LIMIT 1',
+    [stripeSubscriptionId]
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return {
+    id: rows[0].id,
+    tenant_id: rows[0].tenant_id,
+  };
+}
+
+export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Subscription): Promise<void> {
+  const stripeSubscriptionId = stripeSubscription.id;
+  const status = stripeSubscription.status as SubscriptionStatus;
+  const currentPeriodStart = (stripeSubscription.items?.data?.[0]?.current_period_start || 0) * 1000;
+  const currentPeriodEnd = (stripeSubscription.items?.data?.[0]?.current_period_end || 0) * 1000;
+  const cancelAtPeriodEnd = stripeSubscription.cancel_at_period_end ?? false;
+  const canceledAt = stripeSubscription.canceled_at ? stripeSubscription.canceled_at * 1000 : null;
+
+  await pool.query<ResultSetHeader>(
+    `UPDATE subscriptions
+     SET status = ?,
+         current_period_start = ?,
+         current_period_end = ?,
+         cancel_at_period_end = ?,
+         canceled_at = ?
+     WHERE stripe_subscription_id = ?`,
+    [status, currentPeriodStart, currentPeriodEnd, cancelAtPeriodEnd, canceledAt, stripeSubscriptionId]
+  );
+}
+
+export async function syncSubscriptionByStripeId(stripeSubscriptionId: string): Promise<void> {
+  if (!stripe) {
+    return;
+  }
+
+  const stripeSubscription = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+  await upsertSubscriptionFromStripe(stripeSubscription);
+}
+
+export async function upsertInvoiceFromStripe(invoice: Stripe.Invoice): Promise<void> {
+  const stripeSubscriptionId =
+    typeof invoice.subscription === 'string' ? invoice.subscription : invoice.subscription?.id;
+
+  if (!stripeSubscriptionId) {
+    return;
+  }
+
+  const subscriptionRow = await getSubscriptionRowByStripeId(stripeSubscriptionId);
+  if (!subscriptionRow) {
+    return;
+  }
+
+  const dueDateSeconds = invoice.due_date ?? invoice.created ?? Math.floor(Date.now() / 1000);
+  const paidAtSeconds = invoice.status_transitions?.paid_at ?? null;
+  const paidAt = paidAtSeconds ? paidAtSeconds * 1000 : null;
+  const hostedInvoiceUrl = invoice.hosted_invoice_url ?? null;
+  const invoicePdf = invoice.invoice_pdf ?? null;
+  const description = invoice.description ?? null;
+  const [existingInvoiceRows] = await pool.query<RowDataPacket[]>(
+    'SELECT id FROM invoices WHERE stripe_invoice_id = ? LIMIT 1',
+    [invoice.id]
+  );
+  const existingInvoiceId = existingInvoiceRows[0]?.id ?? null;
+
+  if (existingInvoiceId) {
+    await pool.query<ResultSetHeader>(
+      `UPDATE invoices
+       SET amount_due = ?,
+           amount_paid = ?,
+           status = ?,
+           due_date = ?,
+           paid_at = ?,
+           hosted_invoice_url = ?,
+           invoice_pdf = ?,
+           description = ?
+       WHERE id = ?`,
+      [
+        invoice.amount_due ?? 0,
+        invoice.amount_paid ?? 0,
+        invoice.status ?? 'draft',
+        dueDateSeconds * 1000,
+        paidAt,
+        hostedInvoiceUrl,
+        invoicePdf,
+        description,
+        existingInvoiceId,
+      ]
+    );
+    return;
+  }
+
+  const invoiceId = uuidv4();
+  await pool.query<ResultSetHeader>(
+    `INSERT INTO invoices
+     (id, tenant_id, subscription_id, amount_due, amount_paid, status, due_date, paid_at, hosted_invoice_url, invoice_pdf, stripe_invoice_id, description)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      invoiceId,
+      subscriptionRow.tenant_id,
+      subscriptionRow.id,
+      invoice.amount_due ?? 0,
+      invoice.amount_paid ?? 0,
+      invoice.status ?? 'draft',
+      dueDateSeconds * 1000,
+      paidAt,
+      hostedInvoiceUrl,
+      invoicePdf,
+      invoice.id,
+      description,
+    ]
+  );
+}
+
 /**
  * Cancel subscription at period end
  */
@@ -576,8 +697,8 @@ export async function checkPlanLimits(tenantId: string): Promise<{
 }> {
   const subscription = await getTenantSubscription(tenantId);
   
-  // If no subscription or in limited mode (past_due/unpaid), use free tier limits
-  const effectivePlanId = (subscription?.status === 'past_due' || subscription?.status === 'unpaid') 
+  // If no subscription or in limited mode (past_due/unpaid/incomplete), use free tier limits
+  const effectivePlanId = (subscription?.status === 'past_due' || subscription?.status === 'unpaid' || subscription?.status === 'incomplete' || subscription?.status === 'incomplete_expired')
     ? 'plan_free' 
     : subscription?.plan_id || 'plan_free';
   

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ function App() {
   const location = useLocation()
   const navigate = useNavigate()
   const { user, token, loading: authLoading, logout, loginWithDevice, getTenantUsers, viewOnlyMode, viewingTenantId, exitViewMode } = useAuth()
-  const { updateQuantity, fetchLimits } = useSubscription()
+  const { subscription, createBillingPortalSession, fetchLimits } = useSubscription()
   
   // Handle accept-invitation route (doesn't require authentication)
   if (location.pathname === '/accept-invitation') {
@@ -708,8 +708,16 @@ function App() {
       createdAt: Date.now(),
     }
     await setChildrenList((current) => [...(current || []), newChild])
-    void updateQuantity((childrenList || []).length + 1)
     toast.success(`${newChild.name} added!`)
+    if (subscription?.plan?.tier === 'paid') {
+      const portalUrl = await createBillingPortalSession()
+      if (portalUrl) {
+        toast.message('Redirecting to Stripe to update your subscription quantity.')
+        window.location.assign(portalUrl)
+      } else {
+        toast.error('Unable to open Stripe billing portal.')
+      }
+    }
     // Re-fetch limits to immediately update canAddChild status
     await fetchLimits()
   })
@@ -731,10 +739,17 @@ function App() {
     await setAssignments((current) => (current || []).filter((a) => a.childId !== id))
     await setCompletions((current) => (current || []).filter((c) => c.childId !== id))
     await setChildAvailability((current) => (current || []).filter((entry) => entry.childId !== id))
-    
-    const nextCount = Math.max((childrenList || []).length - 1, 0)
-    void updateQuantity(nextCount)
+
     toast.success('Child removed')
+    if (subscription?.plan?.tier === 'paid') {
+      const portalUrl = await createBillingPortalSession()
+      if (portalUrl) {
+        toast.message('Redirecting to Stripe to update your subscription quantity.')
+        window.location.assign(portalUrl)
+      } else {
+        toast.error('Unable to open Stripe billing portal.')
+      }
+    }
     // Re-fetch limits to immediately update canAddChild status
     await fetchLimits()
   })

--- a/src/components/SubscriptionSettings.tsx
+++ b/src/components/SubscriptionSettings.tsx
@@ -7,89 +7,28 @@ import { CreditCard, Check, X, ArrowRight, Warning, Crown, Sparkle } from '@phos
 import { useSubscription } from '@/hooks/use-subscription';
 import { toast } from 'sonner';
 import { SubscriptionPlan } from '@/lib/types';
-import { loadStripe } from '@stripe/stripe-js';
-import { Elements, CardElement, useStripe, useElements } from '@stripe/react-stripe-js';
-
-// Initialize Stripe
-const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || '');
+const STRIPE_DASHBOARD_COPY = 'You will be redirected to Stripe to manage your subscription and payment details.';
 
 interface SubscriptionSettingsProps {
   childrenCount: number;
 }
 
-// Payment form component
-function PaymentForm({ plan, childrenCount, onSuccess }: { 
+// Checkout prompt component
+function CheckoutPrompt({ plan, childrenCount, onSuccess, onRedirect }: { 
   plan: SubscriptionPlan; 
   childrenCount: number;
   onSuccess: () => void;
+  onRedirect: () => Promise<void>;
 }) {
-  const stripe = useStripe();
-  const elements = useElements();
-  const { createPaidSubscription, createSetupIntent } = useSubscription();
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!stripe || !elements) {
-      return;
-    }
-
+  const handleCheckout = async () => {
     setProcessing(true);
     setError(null);
 
     try {
-      // Create setup intent
-      const setupIntentData = await createSetupIntent();
-      if (!setupIntentData) {
-        throw new Error('Failed to create payment setup');
-      }
-
-      const cardElement = elements.getElement(CardElement);
-      if (!cardElement) {
-        throw new Error('Card element not found');
-      }
-
-      // Confirm card setup
-      const { error: stripeError, setupIntent } = await stripe.confirmCardSetup(
-        setupIntentData.clientSecret,
-        {
-          payment_method: {
-            card: cardElement,
-          },
-        }
-      );
-
-      if (stripeError) {
-        throw new Error(stripeError.message);
-      }
-
-      if (!setupIntent?.payment_method) {
-        throw new Error('Payment method not created');
-      }
-
-      // Create subscription
-      const subscriptionResult = await createPaidSubscription(
-        setupIntent.payment_method as string,
-        childrenCount
-      );
-
-      if (!subscriptionResult) {
-        throw new Error('Failed to activate subscription');
-      }
-
-      if (subscriptionResult.clientSecret) {
-        const { error: paymentError } = await stripe.confirmCardPayment(
-          subscriptionResult.clientSecret
-        );
-
-        if (paymentError) {
-          throw new Error(paymentError.message);
-        }
-      }
-
-      toast.success('Subscription activated successfully!');
+      await onRedirect();
       onSuccess();
     } catch (err: any) {
       setError(err.message || 'Payment failed');
@@ -102,28 +41,8 @@ function PaymentForm({ plan, childrenCount, onSuccess }: {
   const monthlyAmount = plan.pricePerChildAUD * childrenCount;
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Card Details</label>
-        <div className="border rounded-lg p-3">
-          <CardElement
-            options={{
-              style: {
-                base: {
-                  fontSize: '16px',
-                  color: '#424770',
-                  '::placeholder': {
-                    color: '#aab7c4',
-                  },
-                },
-                invalid: {
-                  color: '#9e2146',
-                },
-              },
-            }}
-          />
-        </div>
-      </div>
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{STRIPE_DASHBOARD_COPY}</p>
 
       {error && (
         <Alert variant="destructive">
@@ -152,13 +71,14 @@ function PaymentForm({ plan, childrenCount, onSuccess }: {
       </div>
 
       <Button 
-        type="submit" 
+        type="button" 
         className="w-full font-fredoka" 
-        disabled={!stripe || processing}
+        disabled={processing}
+        onClick={handleCheckout}
       >
-        {processing ? 'Processing...' : `Activate Paid Plan - $${monthlyAmount.toFixed(2)} AUD/month`}
+        {processing ? 'Redirecting...' : `Continue to Stripe - $${monthlyAmount.toFixed(2)} AUD/month`}
       </Button>
-    </form>
+    </div>
   );
 }
 
@@ -170,9 +90,8 @@ export function SubscriptionSettings({ childrenCount }: SubscriptionSettingsProp
     loading,
     isLimitedMode,
     effectiveTier,
-    cancelSubscription,
-    reactivateSubscription,
-    downgradePlan,
+    createCheckoutSession,
+    createBillingPortalSession,
     fetchInvoices,
     invoices,
   } = useSubscription();
@@ -188,33 +107,32 @@ export function SubscriptionSettings({ childrenCount }: SubscriptionSettingsProp
   // Check if Stripe is configured
   const isStripeConfigured = Boolean(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY);
 
-  const handleCancelSubscription = async () => {
-    if (!confirm('Are you sure you want to cancel your subscription? It will remain active until the end of the current billing period.')) {
+  const handleManageSubscription = async (successMessage: string) => {
+    const portalUrl = await createBillingPortalSession();
+    if (!portalUrl) {
+      toast.error('Unable to open Stripe billing portal.');
       return;
     }
+    toast.success(successMessage);
+    window.location.assign(portalUrl);
+  };
 
-    const success = await cancelSubscription();
-    if (success) {
-      toast.success('Subscription will be canceled at the end of the billing period');
+  const handleCancelSubscription = async () => {
+    if (!confirm('You will be redirected to Stripe to cancel your subscription. Continue?')) {
+      return;
     }
+    await handleManageSubscription('Redirecting to Stripe to cancel your subscription...');
   };
 
   const handleDowngradeToFree = async () => {
-    if (!confirm('Are you sure you want to downgrade to the Free plan? You will be limited to 1 child, 1 device, 3 chores, and 3 rewards at the end of your current billing period.')) {
+    if (!confirm('You will be redirected to Stripe to manage your plan. Continue?')) {
       return;
     }
-
-    const success = await downgradePlan();
-    if (success) {
-      toast.success('Your plan will be downgraded to Free at the end of the billing period');
-    }
+    await handleManageSubscription('Redirecting to Stripe to manage your plan...');
   };
 
   const handleReactivate = async () => {
-    const success = await reactivateSubscription();
-    if (success) {
-      toast.success('Subscription reactivated successfully');
-    }
+    await handleManageSubscription('Redirecting to Stripe to manage your subscription...');
   };
 
   const handleViewInvoices = () => {
@@ -236,6 +154,15 @@ export function SubscriptionSettings({ childrenCount }: SubscriptionSettingsProp
     }
     setSelectedPlan(plan);
     setShowUpgrade(true);
+  };
+
+  const handleCheckoutRedirect = async () => {
+    if (!selectedPlan) return;
+    const sessionUrl = await createCheckoutSession(childrenCount);
+    if (!sessionUrl) {
+      throw new Error('Unable to start Stripe Checkout.');
+    }
+    window.location.assign(sessionUrl);
   };
 
   if (loading) {
@@ -269,6 +196,9 @@ export function SubscriptionSettings({ childrenCount }: SubscriptionSettingsProp
       past_due: 'bg-orange-500',
       canceled: 'bg-gray-500',
       unpaid: 'bg-red-500',
+      incomplete: 'bg-yellow-500',
+      incomplete_expired: 'bg-red-500',
+      trialing: 'bg-blue-500',
     };
 
     return (
@@ -551,7 +481,7 @@ export function SubscriptionSettings({ childrenCount }: SubscriptionSettingsProp
             <div className="flex items-center justify-between">
               <div>
                 <CardTitle className="font-fredoka">Upgrade to {selectedPlan.name} Plan</CardTitle>
-                <CardDescription>Enter your payment details to activate</CardDescription>
+                <CardDescription>Complete your upgrade securely in Stripe</CardDescription>
               </div>
               <Button variant="ghost" onClick={() => setShowUpgrade(false)}>
                 <X className="h-4 w-4" />
@@ -559,13 +489,12 @@ export function SubscriptionSettings({ childrenCount }: SubscriptionSettingsProp
             </div>
           </CardHeader>
           <CardContent>
-            <Elements stripe={stripePromise}>
-              <PaymentForm
-                plan={selectedPlan}
-                childrenCount={childrenCount}
-                onSuccess={() => setShowUpgrade(false)}
-              />
-            </Elements>
+            <CheckoutPrompt
+              plan={selectedPlan}
+              childrenCount={childrenCount}
+              onSuccess={() => setShowUpgrade(false)}
+              onRedirect={handleCheckoutRedirect}
+            />
           </CardContent>
         </Card>
       )}

--- a/src/hooks/use-subscription.ts
+++ b/src/hooks/use-subscription.ts
@@ -183,60 +183,60 @@ export function useSubscription() {
     }
   }, [mapInvoice, token]);
 
-  // Create setup intent for payment method
-  const createSetupIntent = useCallback(async (): Promise<{ clientSecret: string; customerId: string } | null> => {
+  // Create Stripe Checkout session for a paid subscription
+  const createCheckoutSession = useCallback(async (childrenCount: number): Promise<string | null> => {
     if (!token) return null;
 
     try {
-      const response = await fetch(`${API_URL}/subscriptions/create-setup-intent`, {
+      const response = await fetch(`${API_URL}/subscriptions/checkout-session`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ childrenCount }),
       });
 
       if (!response.ok) {
-        throw new Error('Failed to create setup intent');
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to create checkout session');
       }
 
-      return await response.json();
+      const result = await response.json();
+      return result.url || null;
     } catch (err: any) {
-      console.error('Error creating setup intent:', err);
+      console.error('Error creating checkout session:', err);
       setError(err.message);
       return null;
     }
   }, [token]);
 
-  // Create paid subscription
-  const createPaidSubscription = useCallback(async (paymentMethodId: string, childrenCount: number): Promise<{ clientSecret?: string } | null> => {
+  // Create Stripe Billing Portal session
+  const createBillingPortalSession = useCallback(async (): Promise<string | null> => {
     if (!token) return null;
 
     try {
-      const response = await fetch(`${API_URL}/subscriptions/create`, {
+      const response = await fetch(`${API_URL}/subscriptions/billing-portal`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ paymentMethodId, childrenCount }),
       });
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to create subscription');
+        throw new Error(errorData.error || 'Failed to create billing portal session');
       }
 
       const result = await response.json();
-      await fetchSubscription();
-      await fetchLimits();
-      return result;
+      return result.url || null;
     } catch (err: any) {
-      console.error('Error creating subscription:', err);
+      console.error('Error creating billing portal session:', err);
       setError(err.message);
       return null;
     }
-  }, [token, fetchSubscription, fetchLimits]);
+  }, [token]);
 
   // Cancel subscription
   const cancelSubscription = useCallback(async (): Promise<boolean> => {
@@ -292,34 +292,6 @@ export function useSubscription() {
     }
   }, [token, fetchSubscription]);
 
-  // Update subscription quantity
-  const updateQuantity = useCallback(async (childrenCount: number): Promise<boolean> => {
-    if (!token) return false;
-
-    try {
-      const response = await fetch(`${API_URL}/subscriptions/update-quantity`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ childrenCount }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to update quantity');
-      }
-
-      await fetchSubscription();
-      return true;
-    } catch (err: any) {
-      console.error('Error updating quantity:', err);
-      setError(err.message);
-      return false;
-    }
-  }, [token, fetchSubscription]);
-
   // Downgrade to free plan
   const downgradePlan = useCallback(async (): Promise<boolean> => {
     if (!token) return false;
@@ -356,8 +328,11 @@ export function useSubscription() {
     }
   }, [token, user, fetchPlans, fetchSubscription, fetchLimits]);
 
-  // Check if account is in limited mode (past_due or unpaid)
-  const isLimitedMode = subscription?.status === 'past_due' || subscription?.status === 'unpaid';
+  // Check if account is in limited mode (past_due, unpaid, or incomplete)
+  const isLimitedMode = subscription?.status === 'past_due'
+    || subscription?.status === 'unpaid'
+    || subscription?.status === 'incomplete'
+    || subscription?.status === 'incomplete_expired';
   
   // Get effective tier (Free if in limited mode)
   const effectiveTier = isLimitedMode ? 'free' : subscription?.plan?.tier || 'free';
@@ -374,11 +349,10 @@ export function useSubscription() {
     fetchSubscription,
     fetchLimits,
     fetchInvoices,
-    createSetupIntent,
-    createPaidSubscription,
+    createCheckoutSession,
+    createBillingPortalSession,
     cancelSubscription,
     reactivateSubscription,
-    updateQuantity,
     downgradePlan,
   };
 }


### PR DESCRIPTION
### Motivation
- Stop collecting card details in-app and ensure subscription quantity/plan changes are handled in Stripe-hosted flows to avoid mismatched billing state and simplify PCI scope.
- Persist Stripe subscription and invoice state locally and treat unpaid/incomplete Stripe statuses as limited access so frontend/backend limits remain consistent.

### Description
- Backend: added `/checkout-session` and `/billing-portal` endpoints in `server/src/routes/subscriptions.ts` to create Stripe Checkout sessions and Billing Portal sessions, and wired webhook handling to call `upsertInvoiceFromStripe`, `upsertSubscriptionFromStripe`, and `syncSubscriptionByStripeId` so Stripe events persist to the DB and trigger resyncs. 
- Services: implemented `getSubscriptionRowByStripeId`, `upsertSubscriptionFromStripe`, `syncSubscriptionByStripeId`, and `upsertInvoiceFromStripe` in `server/src/services/subscription.ts` and fixed invoice upsert detection by `stripe_invoice_id`. 
- Frontend hooks/UI: replaced in-app card collection with Stripe redirects by removing `createSetupIntent`/`createPaidSubscription`/`updateQuantity` and adding `createCheckoutSession` and `createBillingPortalSession` in `src/hooks/use-subscription.ts`. 
- UI changes: removed `Elements`/card form and added a `CheckoutPrompt` that redirects users to Stripe Checkout for upgrades, and updated `SubscriptionSettings.tsx` to route cancel/reactivate/downgrade/manage actions to the Stripe Billing Portal. 
- App flow: updated `src/App.tsx` to redirect users to the Billing Portal when adding/removing children for paid subscriptions instead of updating quantity in-app, and broadened limited-mode logic to treat `incomplete`/`incomplete_expired` as limited. 

### Testing
- Started the frontend dev server with `npm run dev` and confirmed Vite reported the site ready at `http://localhost:5000` which succeeded. 
- Captured a UI screenshot of the subscription settings page using a Playwright script to validate the updated prompt and flows, which produced `artifacts/subscription-settings.png` successfully. 
- No automated unit tests were added or run beyond the dev server and Playwright UI check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698407e28fbc833290c0b7433d09b084)