### PR TITLE
Fix Stripe invoice subscription lookup

### DIFF
--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -482,8 +482,10 @@ export async function syncSubscriptionByStripeId(stripeSubscriptionId: string): 
 }
 
 export async function upsertInvoiceFromStripe(invoice: Stripe.Invoice): Promise<void> {
+  const legacySubscription = (invoice as { subscription?: string | Stripe.Subscription | null }).subscription;
+  const subscriptionReference = legacySubscription ?? invoice.parent?.subscription_details?.subscription;
   const stripeSubscriptionId =
-    typeof invoice.subscription === 'string' ? invoice.subscription : invoice.subscription?.id;
+    typeof subscriptionReference === 'string' ? subscriptionReference : subscriptionReference?.id;
 
   if (!stripeSubscriptionId) {
     return;


### PR DESCRIPTION
### Motivation
- Stripe's `Invoice` shape can surface the originating subscription under `parent.subscription_details.subscription` with newer typings, so invoice subscription lookups must handle that while keeping a legacy fallback to the older `invoice.subscription` field.

### Description
- Update `upsertInvoiceFromStripe` in `server/src/services/subscription.ts` to derive the Stripe subscription id from a `legacySubscription` fallback or from `invoice.parent?.subscription_details?.subscription` and then normalize to an id string.

### Testing
- No automated tests or TypeScript build were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69840df90b48833294226b2a83b8b8e2)