### PR TITLE
Fix subscription creation validation for paid upgrades

### DIFF
--- a/server/src/routes/subscriptions.ts
+++ b/server/src/routes/subscriptions.ts
@@ -91,17 +91,35 @@ router.post('/create', authenticateToken, async (req: AuthRequest, res: Response
       return res.status(401).json({ error: 'Unauthorized' });
     }
     
-    const { paymentMethodId, childrenCount } = req.body;
-    
-    if (!paymentMethodId || !childrenCount) {
-      return res.status(400).json({ error: 'Missing required fields' });
+    const { paymentMethodId, payment_method_id, childrenCount, children_count } = req.body;
+    const resolvedPaymentMethodId = paymentMethodId ?? payment_method_id;
+    let resolvedChildrenCount: number | null | undefined = childrenCount ?? children_count;
+
+    if (resolvedChildrenCount === undefined || resolvedChildrenCount === null) {
+      const limits = await checkPlanLimits(tenantId);
+      resolvedChildrenCount = limits.current.children;
     }
-    
-    if (childrenCount < 1) {
+
+    const normalizedChildrenCount = Number(resolvedChildrenCount);
+
+    if (!resolvedPaymentMethodId) {
+      return res.status(400).json({ error: 'Missing payment method' });
+    }
+
+    if (Number.isNaN(normalizedChildrenCount)) {
+      return res.status(400).json({ error: 'Invalid children count' });
+    }
+
+    if (normalizedChildrenCount < 1) {
       return res.status(400).json({ error: 'Must have at least 1 child' });
     }
-    
-    const result = await createPaidSubscription(tenantId, email, paymentMethodId, childrenCount);
+
+    const result = await createPaidSubscription(
+      tenantId,
+      email,
+      resolvedPaymentMethodId,
+      normalizedChildrenCount,
+    );
     res.json(result);
   } catch (error: any) {
     console.error('Error creating subscription:', error);


### PR DESCRIPTION
### Motivation
- Prevent 400 (Missing required fields) errors when creating paid subscriptions due to variant request shapes or omitted children count.
- Accept snake_case and camelCase request fields from different frontends and derive missing child count from current usage.
- Provide clearer validation errors for missing payment method and invalid children counts.

### Description
- Updated `POST /api/subscriptions/create` to accept `paymentMethodId` or `payment_method_id` and `childrenCount` or `children_count` from the request body.
- If children count is omitted, the handler now calls `checkPlanLimits()` to derive the current number of children and uses that as the quantity.
- Normalizes the children count to a `Number`, validates it is a numeric value and at least `1`, and returns explicit `400` errors for missing payment method or invalid counts.
- Passes the resolved payment method and normalized children count to `createPaidSubscription`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69841c0d72bc833281858b80648fac54)