### PR TITLE
Fix Stripe product search query quoting

### DIFF
--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -74,7 +74,7 @@ export async function getOrCreateStripeProduct(): Promise<string> {
   // Search for existing product by name (escape single quotes for safety)
   const escapedProductName = escapeStripeSearchQuery(STRIPE_PRODUCT_NAME);
   const existingProducts = await stripe.products.search({
-    query: `name:'${escapedProductName}' AND active:true`,
+    query: `name:'${escapedProductName}' AND active:\"true\"`,
     limit: 1,
   });
 


### PR DESCRIPTION
### Motivation
- Fix a 500 error when creating a Stripe Checkout session caused by an invalid `products.search` query that required the `active` flag to be quoted (error suggested using `active:"true"`).

### Description
- Update the Stripe product search query in `getOrCreateStripeProduct` to use `query: `name:'${escapedProductName}' AND active:"true"`` in `server/src/services/subscription.ts` so the search matches Stripe's expected syntax.

### Testing
- No automated tests were run for this change (commit contains only the single-line query fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984399c13088332bc6a2284579aad0e)