### PR TITLE
Normalize cancel-at-period-end flag to boolean in subscription mapping

### DIFF
--- a/src/hooks/use-subscription.ts
+++ b/src/hooks/use-subscription.ts
@@ -63,7 +63,9 @@ export function useSubscription() {
       status: subscription.status,
       currentPeriodStart: subscription.current_period_start ?? subscription.currentPeriodStart,
       currentPeriodEnd: subscription.current_period_end ?? subscription.currentPeriodEnd,
-      cancelAtPeriodEnd: subscription.cancel_at_period_end ?? subscription.cancelAtPeriodEnd,
+      cancelAtPeriodEnd: Boolean(
+        subscription.cancel_at_period_end ?? subscription.cancelAtPeriodEnd,
+      ),
       canceledAt: subscription.canceled_at ?? subscription.canceledAt ?? null,
       stripeCustomerId: subscription.stripe_customer_id ?? subscription.stripeCustomerId ?? null,
       stripeSubscriptionId: subscription.stripe_subscription_id ?? subscription.stripeSubscriptionId ?? null,


### PR DESCRIPTION
### Motivation
- The API can return `cancel_at_period_end` as a numeric `0`, which ends up rendering as `0` in JSX conditionals using `&&`, so the value must be normalized to avoid stray `0` appearing in the UI.

### Description
- Normalize the cancel flag by setting `cancelAtPeriodEnd` to `Boolean(subscription.cancel_at_period_end ?? subscription.cancelAtPeriodEnd)` in `src/hooks/use-subscription.ts` so the mapped subscription always exposes a proper boolean.

### Testing
- No automated tests were executed; this is a small data-normalization fix that was verified by code inspection and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69843b20cc2c8332aa2c956b8a9cc3f0)