### PR TITLE
Fix Stripe webhook sync to update tenant subscription to Paid after checkout

### DIFF
--- a/server/src/routes/subscriptions.ts
+++ b/server/src/routes/subscriptions.ts
@@ -402,6 +402,7 @@ router.post('/webhook', async (req: Request, res: Response) => {
     
     // Handle the event
     switch (event.type) {
+      case 'customer.subscription.created':
       case 'customer.subscription.updated':
       case 'customer.subscription.deleted': {
         const subscription = event.data.object as any;

--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -567,16 +567,101 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
   const currentPeriodEnd = (stripeSubscription.items?.data?.[0]?.current_period_end || 0) * 1000;
   const cancelAtPeriodEnd = stripeSubscription.cancel_at_period_end ?? false;
   const canceledAt = stripeSubscription.canceled_at ? stripeSubscription.canceled_at * 1000 : null;
+  const stripeCustomerId = typeof stripeSubscription.customer === 'string'
+    ? stripeSubscription.customer
+    : stripeSubscription.customer?.id ?? null;
 
-  await pool.query<ResultSetHeader>(
+  const [updateResult] = await pool.query<ResultSetHeader>(
     `UPDATE subscriptions
-     SET status = ?,
+     SET plan_id = ?,
+         status = ?,
          current_period_start = ?,
          current_period_end = ?,
          cancel_at_period_end = ?,
-         canceled_at = ?
+         canceled_at = ?,
+         stripe_customer_id = COALESCE(stripe_customer_id, ?)
      WHERE stripe_subscription_id = ?`,
-    [status, currentPeriodStart, currentPeriodEnd, cancelAtPeriodEnd, canceledAt, stripeSubscriptionId]
+    [
+      'plan_paid',
+      status,
+      currentPeriodStart,
+      currentPeriodEnd,
+      cancelAtPeriodEnd,
+      canceledAt,
+      stripeCustomerId,
+      stripeSubscriptionId,
+    ]
+  );
+
+  if (updateResult.affectedRows > 0) {
+    return;
+  }
+
+  const metadataTenantId = stripeSubscription.metadata?.tenant_id || stripeSubscription.metadata?.tenantId;
+  let tenantId = metadataTenantId ?? null;
+
+  if (!tenantId && stripeCustomerId) {
+    const [rows] = await pool.query<RowDataPacket[]>(
+      'SELECT tenant_id FROM subscriptions WHERE stripe_customer_id = ? ORDER BY created_at DESC LIMIT 1',
+      [stripeCustomerId]
+    );
+    tenantId = rows[0]?.tenant_id ?? null;
+  }
+
+  if (!tenantId) {
+    return;
+  }
+
+  const [existingRows] = await pool.query<RowDataPacket[]>(
+    'SELECT id FROM subscriptions WHERE tenant_id = ? ORDER BY created_at DESC LIMIT 1',
+    [tenantId]
+  );
+  const existingId = existingRows[0]?.id ?? null;
+
+  if (existingId) {
+    await pool.query<ResultSetHeader>(
+      `UPDATE subscriptions
+       SET plan_id = ?,
+           status = ?,
+           current_period_start = ?,
+           current_period_end = ?,
+           cancel_at_period_end = ?,
+           canceled_at = ?,
+           stripe_customer_id = ?,
+           stripe_subscription_id = ?
+       WHERE id = ?`,
+      [
+        'plan_paid',
+        status,
+        currentPeriodStart,
+        currentPeriodEnd,
+        cancelAtPeriodEnd,
+        canceledAt,
+        stripeCustomerId,
+        stripeSubscriptionId,
+        existingId,
+      ]
+    );
+    return;
+  }
+
+  const subscriptionId = uuidv4();
+  await pool.query<ResultSetHeader>(
+    `INSERT INTO subscriptions
+     (id, tenant_id, plan_id, status, current_period_start, current_period_end, stripe_customer_id, stripe_subscription_id, cancel_at_period_end, canceled_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      subscriptionId,
+      tenantId,
+      'plan_paid',
+      status,
+      currentPeriodStart,
+      currentPeriodEnd,
+      stripeCustomerId,
+      stripeSubscriptionId,
+      cancelAtPeriodEnd,
+      canceledAt,
+    ]
   );
 }
 


### PR DESCRIPTION
### Motivation
- Stripe Checkout created subscriptions were not being mapped to tenants in the app, so successful payments left the app showing the Free plan. 
- The webhook handler only processed `customer.subscription.updated`/`deleted` events which missed newly created subscriptions from Checkout. 
- The upsert logic did not create or update subscription rows when Stripe returned a new subscription without an existing `stripe_subscription_id` row. 

### Description
- Updated `upsertSubscriptionFromStripe` to extract the Stripe customer id from the subscription and attempt an `UPDATE` by `stripe_subscription_id` that also sets `plan_id = 'plan_paid'` and preserves or writes `stripe_customer_id` using `COALESCE(stripe_customer_id, ?)`. 
- If the initial update affects no rows, the function now resolves the tenant id from `stripeSubscription.metadata.tenant_id` or by looking up a subscription with the same `stripe_customer_id`, then updates the latest subscription row for that tenant or inserts a new subscription row with `plan_id = 'plan_paid'` and the Stripe ids. 
- Added `customer.subscription.created` to the webhook `switch` in `server/src/routes/subscriptions.ts` so new subscriptions created by Checkout trigger the same sync flow. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984409321b08332bd656d7e55529e4d)