### PR TITLE
Fix Stripe webhook raw body handling

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -30,7 +30,17 @@ const corsOptions = {
 };
 app.use(cors(corsOptions));
 app.use(bodyParser.text({ type: 'text/plain', limit: '10mb' })); // For Spark runtime KV requests
-app.use(bodyParser.json({ limit: '10mb' }));
+app.use('/api/subscriptions/webhook', bodyParser.raw({ type: 'application/json' }));
+app.use(bodyParser.json({
+  limit: '10mb',
+  type: (req) => {
+    if (req.originalUrl === '/api/subscriptions/webhook') {
+      return false;
+    }
+    const contentType = req.headers['content-type'] || '';
+    return contentType.includes('application/json') || contentType.includes('+json');
+  },
+}));
 app.use(bodyParser.urlencoded({ extended: true, limit: '10mb' }));
 
 // Rate limiting configuration - applied AFTER body parser


### PR DESCRIPTION
### Motivation

- Stripe webhook signature verification was failing because the request body was parsed into an object instead of preserving the raw payload required by `stripe.webhooks.constructEvent`.

### Description

- Added a raw JSON body parser specifically for the webhook route with `app.use('/api/subscriptions/webhook', bodyParser.raw({ type: 'application/json' }));`.
- Adjusted the global JSON parser to skip the webhook path by using a custom `type` function so the webhook route receives the unparsed raw body.
- Kept the existing text and urlencoded parsers intact so other endpoints continue to function as before.
- Change applied to `server/src/index.ts` to ensure the signed payload is preserved for Stripe signature verification.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698525729fd48332aeaf808d6089e65a)