### PR TITLE
Fix request URL typing in API body parser

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,7 +34,9 @@ app.use('/api/subscriptions/webhook', bodyParser.raw({ type: 'application/json' 
 app.use(bodyParser.json({
   limit: '10mb',
   type: (req) => {
-    if (req.originalUrl === '/api/subscriptions/webhook') {
+    const request = req as express.Request;
+    const requestUrl = request.originalUrl ?? req.url ?? '';
+    if (requestUrl === '/api/subscriptions/webhook') {
       return false;
     }
     const contentType = req.headers['content-type'] || '';


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript build error (TS2339) when accessing `originalUrl` on the incoming request so the Docker image can build and the webhook body-parsing skip logic remains functional.

### Description
- Replace direct use of `req.originalUrl` with a safe lookup by casting to `express.Request` and computing `request.originalUrl ?? req.url ?? ''` inside the `bodyParser.json` `type` function to avoid type errors while preserving the webhook skip behavior.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698526e0ec3483329d55bd02ed37357e)