### PR TITLE
Handle additional Stripe webhook events and centralize invoice syncing

### DIFF
--- a/server/src/routes/subscriptions.ts
+++ b/server/src/routes/subscriptions.ts
@@ -400,6 +400,17 @@ router.post('/webhook', async (req: Request, res: Response) => {
       return res.status(400).json({ error: `Webhook Error: ${err.message}` });
     }
     
+    const handleInvoiceEvent = async (invoice: any, context: string) => {
+      await upsertInvoiceFromStripe(invoice);
+      if (invoice.subscription) {
+        const stripeSubscriptionId = typeof invoice.subscription === 'string'
+          ? invoice.subscription
+          : invoice.subscription.id;
+        await syncSubscriptionByStripeId(stripeSubscriptionId);
+      }
+      console.log(`Invoice ${context}:`, invoice.id);
+    };
+
     // Handle the event
     switch (event.type) {
       case 'checkout.session.completed': {
@@ -426,27 +437,53 @@ router.post('/webhook', async (req: Request, res: Response) => {
 
       case 'invoice.paid': {
         const invoice = event.data.object as any;
-        await upsertInvoiceFromStripe(invoice);
-        if (invoice.subscription) {
-          const stripeSubscriptionId = typeof invoice.subscription === 'string'
-            ? invoice.subscription
-            : invoice.subscription.id;
-          await syncSubscriptionByStripeId(stripeSubscriptionId);
-        }
-        console.log('Invoice paid:', invoice.id);
+        await handleInvoiceEvent(invoice, 'paid');
         break;
       }
 
       case 'invoice.payment_failed': {
         const failedInvoice = event.data.object as any;
-        await upsertInvoiceFromStripe(failedInvoice);
-        if (failedInvoice.subscription) {
-          const stripeSubscriptionId = typeof failedInvoice.subscription === 'string'
-            ? failedInvoice.subscription
-            : failedInvoice.subscription.id;
-          await syncSubscriptionByStripeId(stripeSubscriptionId);
+        await handleInvoiceEvent(failedInvoice, 'payment failed');
+        break;
+      }
+
+      case 'invoice.created': {
+        const invoice = event.data.object as any;
+        await handleInvoiceEvent(invoice, 'created');
+        break;
+      }
+
+      case 'invoice.finalized': {
+        const invoice = event.data.object as any;
+        await handleInvoiceEvent(invoice, 'finalized');
+        break;
+      }
+
+      case 'payment_intent.created': {
+        const paymentIntent = event.data.object as any;
+        if (paymentIntent.invoice) {
+          const invoiceId = typeof paymentIntent.invoice === 'string'
+            ? paymentIntent.invoice
+            : paymentIntent.invoice.id;
+          const invoice = await stripe.invoices.retrieve(invoiceId);
+          await handleInvoiceEvent(invoice, 'payment intent created');
+        } else {
+          console.log('Payment intent created:', paymentIntent.id);
         }
-        console.log('Invoice payment failed:', failedInvoice.id);
+        break;
+      }
+
+      case 'payment_intent.succeeded': {
+        const paymentIntent = event.data.object as any;
+        if (paymentIntent.invoice) {
+          const invoiceId = typeof paymentIntent.invoice === 'string'
+            ? paymentIntent.invoice
+            : paymentIntent.invoice.id;
+          const invoice = await stripe.invoices.retrieve(invoiceId);
+          await handleInvoiceEvent(invoice, 'payment intent succeeded');
+        } else {
+          console.log('Payment intent succeeded:', paymentIntent.id);
+        }
         break;
       }
       


### PR DESCRIPTION
### Motivation
- Fix missing handling for Stripe webhook events observed during user subscription flow errors such as `payment_intent.created`, `invoice.created`, `invoice.finalized`, and `payment_intent.succeeded` so invoices and subscriptions stay in sync. 
- Reduce duplication by centralizing invoice upsert and subscription sync logic for webhook-driven invoice flows.

### Description
- Add `handleInvoiceEvent` helper in `server/src/routes/subscriptions.ts` to call `upsertInvoiceFromStripe()` and `syncSubscriptionByStripeId()` and log the invoice context. 
- Replace inline invoice handling for `invoice.paid` and `invoice.payment_failed` to use the new helper. 
- Add explicit handlers for `invoice.created` and `invoice.finalized` that reuse the helper. 
- Add support for `payment_intent.created` and `payment_intent.succeeded`, which retrieve the related invoice via `stripe.invoices.retrieve()` when present and pass it to the helper, otherwise log the payment intent.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69852d3420e08332851505e1487fa33c)