### PR TITLE
Guard against deleted Stripe customer when reading metadata

### DIFF
--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -622,8 +622,9 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
   if (!tenantId && stripeCustomerId && stripe) {
     try {
       const customer = await stripe.customers.retrieve(stripeCustomerId);
-      if (!Array.isArray(customer)) {
-        tenantId = customer.metadata?.tenant_id || customer.metadata?.tenantId || tenantId;
+      if (!Array.isArray(customer) && !('deleted' in customer && customer.deleted)) {
+        const stripeCustomer = customer as Stripe.Customer;
+        tenantId = stripeCustomer.metadata?.tenant_id || stripeCustomer.metadata?.tenantId || tenantId;
       }
     } catch (error: unknown) {
       console.warn('Unable to retrieve Stripe customer metadata for subscription sync:',


### PR DESCRIPTION
### Motivation
- Fix a TypeScript build error in the subscription sync caused by accessing `metadata` on a Stripe API response that can be a `DeletedCustomer`, which breaks the Docker build.

### Description
- Update `server/src/services/subscription.ts` to check that the retrieved customer is not deleted before accessing `metadata`, and cast the result to `Stripe.Customer` when reading `tenant_id` metadata.

### Testing
- No automated tests or builds were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69853553eecc8332b6192b0f6848df8e)