### PR TITLE
Add Stripe refresh for admin subscriptions

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 import { pool } from '../config/database.js';
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import { requireAdmin } from '../middleware/adminAuth.js';
-import { getTenantSubscription, getSubscriptionPlan } from '../services/subscription.js';
+import { getTenantSubscription, getSubscriptionPlan, syncTenantSubscription } from '../services/subscription.js';
 import {
   clearGlobalPricePerChild,
   clearTenantPricePerChild,
@@ -394,6 +394,40 @@ router.put('/subscriptions/:tenantId', requireAdmin, async (req: Request, res: R
     res.status(500).json({ error: 'Failed to update tenant subscription' });
   } finally {
     connection.release();
+  }
+});
+
+/**
+ * Refresh subscription status for a specific tenant via Stripe
+ * POST /api/admin/subscriptions/:tenantId/refresh
+ */
+router.post('/subscriptions/:tenantId/refresh', requireAdmin, async (req: Request, res: Response) => {
+  try {
+    const { tenantId } = req.params;
+
+    const [tenantRows] = await pool.query<RowDataPacket[]>(
+      'SELECT id FROM tenants WHERE id = ?',
+      [tenantId]
+    );
+
+    if (tenantRows.length === 0) {
+      return res.status(404).json({ error: 'Tenant not found' });
+    }
+
+    const subscription = await syncTenantSubscription(tenantId);
+
+    if (!subscription) {
+      return res.status(404).json({ error: 'No subscription found for this tenant' });
+    }
+
+    res.json({ subscription });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to refresh tenant subscription';
+    console.error('Error refreshing tenant subscription:', message);
+    if (message === 'Stripe is not configured') {
+      return res.status(503).json({ error: message });
+    }
+    res.status(500).json({ error: 'Failed to refresh tenant subscription' });
   }
 });
 

--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -697,6 +697,37 @@ export async function syncSubscriptionByStripeId(stripeSubscriptionId: string): 
   await upsertSubscriptionFromStripe(stripeSubscription);
 }
 
+export async function syncTenantSubscription(tenantId: string): Promise<TenantSubscription | null> {
+  if (!stripe) {
+    throw new Error('Stripe is not configured');
+  }
+
+  const subscription = await getTenantSubscription(tenantId);
+  if (!subscription) {
+    return null;
+  }
+
+  if (subscription.stripe_subscription_id) {
+    await syncSubscriptionByStripeId(subscription.stripe_subscription_id);
+    return await getTenantSubscription(tenantId);
+  }
+
+  if (subscription.stripe_customer_id) {
+    const stripeSubscriptions = await stripe.subscriptions.list({
+      customer: subscription.stripe_customer_id,
+      limit: 1,
+      status: 'all',
+    });
+    const stripeSubscription = stripeSubscriptions.data[0];
+    if (stripeSubscription) {
+      await upsertSubscriptionFromStripe(stripeSubscription);
+      return await getTenantSubscription(tenantId);
+    }
+  }
+
+  return subscription;
+}
+
 export async function upsertInvoiceFromStripe(invoice: Stripe.Invoice): Promise<void> {
   const subscription = (invoice as Stripe.Invoice & { subscription?: string | Stripe.Subscription }).subscription;
   const stripeSubscriptionId =

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -118,6 +118,8 @@ export function AdminPanel() {
   const { token, user, logout } = useAuth()
   const navigate = useNavigate()
   const [loading, setLoading] = useState(false)
+  const [syncingTenantId, setSyncingTenantId] = useState<string | null>(null)
+  const [syncingAllSubscriptions, setSyncingAllSubscriptions] = useState(false)
   const [tenants, setTenants] = useState<Tenant[]>([])
   const [parents, setParents] = useState<Parent[]>([])
   const [stats, setStats] = useState<Stats | null>(null)
@@ -434,6 +436,65 @@ export function AdminPanel() {
     } finally {
       setChangingSubscription(null)
     }
+  }
+
+  const refreshSubscriptionStatus = async (tenantId: string, options: { silent?: boolean } = {}) => {
+    setSyncingTenantId(tenantId)
+    try {
+      const response = await fetch(`/api/admin/subscriptions/${tenantId}/refresh`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.error || 'Failed to refresh subscription status')
+      }
+
+      const data = await response.json()
+      setTenantsWithSubscriptions((prev) =>
+        prev.map((tenant) =>
+          tenant.id === tenantId
+            ? { ...tenant, subscription: data.subscription || tenant.subscription }
+            : tenant
+        )
+      )
+
+      if (!options.silent) {
+        toast.success('Subscription status refreshed')
+      }
+      return true
+    } catch (error: any) {
+      console.error('Error refreshing subscription status:', error)
+      if (!options.silent) {
+        toast.error(error.message || 'Failed to refresh subscription status')
+      }
+      return false
+    } finally {
+      setSyncingTenantId(null)
+    }
+  }
+
+  const refreshAllSubscriptionStatuses = async () => {
+    setSyncingAllSubscriptions(true)
+    let failures = 0
+
+    for (const tenant of tenantsWithSubscriptions) {
+      const success = await refreshSubscriptionStatus(tenant.id, { silent: true })
+      if (!success) {
+        failures += 1
+      }
+    }
+
+    if (failures === 0) {
+      toast.success('All subscriptions refreshed from Stripe')
+    } else {
+      toast.error(`Refreshed with ${failures} failure${failures > 1 ? 's' : ''}`)
+    }
+
+    setSyncingAllSubscriptions(false)
   }
 
   const deleteParent = async (parentId: string, email: string) => {
@@ -1064,10 +1125,26 @@ export function AdminPanel() {
                       <CardTitle className="text-lg">Subscription Management</CardTitle>
                       <CardDescription className="text-xs">View and manage tenant subscriptions</CardDescription>
                     </div>
-                    <Button variant="outline" size="sm" onClick={fetchSubscriptions} disabled={loading}>
-                      <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
-                      Refresh
-                    </Button>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={fetchSubscriptions}
+                        disabled={loading || syncingAllSubscriptions}
+                      >
+                        <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+                        Refresh
+                      </Button>
+                      <Button
+                        variant="default"
+                        size="sm"
+                        onClick={refreshAllSubscriptionStatuses}
+                        disabled={loading || syncingAllSubscriptions || tenantsWithSubscriptions.length === 0}
+                      >
+                        <RefreshCw className={`h-4 w-4 mr-2 ${syncingAllSubscriptions ? 'animate-spin' : ''}`} />
+                        Refresh from Stripe
+                      </Button>
+                    </div>
                   </div>
                   <div className="mt-3">
                     <div className="relative">
@@ -1094,6 +1171,7 @@ export function AdminPanel() {
                             <TableHead>Limits</TableHead>
                             <TableHead>Period</TableHead>
                             <TableHead>Change Plan</TableHead>
+                            <TableHead className="text-right">Actions</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -1155,12 +1233,23 @@ export function AdminPanel() {
                                     </SelectContent>
                                   </Select>
                                 </TableCell>
+                                <TableCell className="text-right">
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => refreshSubscriptionStatus(tenant.id)}
+                                    disabled={syncingAllSubscriptions || syncingTenantId === tenant.id}
+                                  >
+                                    <RefreshCw className={`h-3 w-3 mr-2 ${syncingTenantId === tenant.id ? 'animate-spin' : ''}`} />
+                                    Refresh
+                                  </Button>
+                                </TableCell>
                               </TableRow>
                             )
                           })}
                           {filteredSubscriptions.length === 0 && !loading && (
                             <TableRow>
-                              <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
+                              <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
                                 No tenants found
                               </TableCell>
                             </TableRow>


### PR DESCRIPTION
### Motivation
- Admins need a way to reconcile subscription state with Stripe so the app shows the correct plan/status for tenants. 
- Provide both per-tenant and bulk refresh actions to avoid full reloads and speed up troubleshooting. 

### Description
- Added `syncTenantSubscription` to `server/src/services/subscription.ts` to lookup and upsert subscription data from Stripe for a tenant and return refreshed subscription data. 
- Exposed a new admin API endpoint `POST /api/admin/subscriptions/:tenantId/refresh` in `server/src/routes/admin.ts` which calls the new sync helper and returns the updated subscription. 
- Updated `src/components/AdminPanel.tsx` to add UI and client logic: per-row `Refresh` button, a bulk `Refresh from Stripe` button, `syncingTenantId` and `syncingAllSubscriptions` states, `refreshSubscriptionStatus()` and `refreshAllSubscriptionStatuses()` functions, and a new Actions column that updates the table row(s) in-place after a successful refresh. 

### Testing
- Started the dev server with `npm run dev` and Vite reported ready on `localhost:5000`, which indicates the frontend build served successfully. 
- Attempted an automated Playwright screenshot of the Admin UI but it failed with `net::ERR_EMPTY_RESPONSE`, so UI interaction tests did not complete. 
- No backend unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698535434c4483328c36d432a194c97b)