### PR TITLE
Update Stripe subscription quantity when children KV changes

### DIFF
--- a/server/src/routes/kv.ts
+++ b/server/src/routes/kv.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 import { pool } from '../config/database.js';
 import type { RowDataPacket } from 'mysql2';
 import { optionalAuth, AuthRequest } from '../middleware/auth.js';
-import { checkPlanLimits } from '../services/subscription.js';
+import { checkPlanLimits, updateSubscriptionQuantity } from '../services/subscription.js';
 
 const router = Router();
 
@@ -176,6 +176,14 @@ router.post('/:key', optionalAuth, async (req: AuthRequest, res: Response) => {
        ON DUPLICATE KEY UPDATE value_data = ?`,
       [key, JSON.stringify(value), tenantId, JSON.stringify(value)]
     );
+
+    if (key === 'children' && Array.isArray(value)) {
+      try {
+        await updateSubscriptionQuantity(tenantId, value.length);
+      } catch (subscriptionError) {
+        console.error('Error updating subscription quantity:', subscriptionError);
+      }
+    }
     
     res.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Keep Stripe billing in sync when the `children` KV entry is updated so subscription quantity reflects added/removed children.

### Description
- Import and call `updateSubscriptionQuantity` from `server/src/services/subscription.ts` in `server/src/routes/kv.ts`.
- After persisting a write to the `children` key, invoke `updateSubscriptionQuantity(tenantId, value.length)` inside a `try/catch` and log any errors without failing the KV write.
- This preserves the existing KV write behavior while attempting to update the Stripe subscription quantity asynchronously.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69853dce270c83328708ba83a4d9aa6f)