### PR TITLE
Deactivate plan-limited items when subscription downgrades to Free

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -2,7 +2,13 @@ import { Router, Request, Response } from 'express';
 import { pool } from '../config/database.js';
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import { requireAdmin } from '../middleware/adminAuth.js';
-import { getTenantSubscription, getSubscriptionPlan, syncTenantSubscription } from '../services/subscription.js';
+import {
+  applyFreePlanDeactivations,
+  getTenantSubscription,
+  getSubscriptionPlan,
+  reactivatePlanItems,
+  syncTenantSubscription,
+} from '../services/subscription.js';
 import {
   clearGlobalPricePerChild,
   clearTenantPricePerChild,
@@ -346,9 +352,10 @@ router.put('/subscriptions/:tenantId', requireAdmin, async (req: Request, res: R
 
     // Get existing subscription
     const [existingSubRows] = await connection.query<RowDataPacket[]>(
-      'SELECT id FROM subscriptions WHERE tenant_id = ? ORDER BY created_at DESC LIMIT 1',
+      'SELECT id, plan_id FROM subscriptions WHERE tenant_id = ? ORDER BY created_at DESC LIMIT 1',
       [tenantId]
     );
+    const previousPlanId = existingSubRows[0]?.plan_id ?? null;
 
     const now = Date.now();
     const oneYearFromNow = now + (365 * 24 * 60 * 60 * 1000);
@@ -379,6 +386,15 @@ router.put('/subscriptions/:tenantId', requireAdmin, async (req: Request, res: R
     }
 
     await connection.commit();
+
+    if (previousPlanId && previousPlanId !== planId) {
+      if (planId === 'plan_free') {
+        await applyFreePlanDeactivations(tenantId);
+      }
+      if (planId === 'plan_paid') {
+        await reactivatePlanItems(tenantId);
+      }
+    }
 
     // Fetch and return updated subscription
     const updatedSubscription = await getTenantSubscription(tenantId);

--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -175,6 +175,82 @@ export async function getSubscriptionPlan(planId: string): Promise<SubscriptionP
   };
 }
 
+async function updatePlanLimitedItems(
+  tenantId: string,
+  keyName: 'children' | 'chores' | 'rewards',
+  maxAllowed: number | null,
+  isActive: boolean
+): Promise<void> {
+  if (maxAllowed === null && !isActive) {
+    return;
+  }
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT value_data FROM kv_store WHERE tenant_id = ? AND key_name = ?',
+    [tenantId, keyName]
+  );
+  if (rows.length === 0) {
+    return;
+  }
+  const valueData = rows[0]?.value_data;
+  if (!valueData) {
+    return;
+  }
+  let items: unknown;
+  try {
+    items = JSON.parse(valueData);
+  } catch (error) {
+    console.error(`Unable to parse kv_store for ${keyName}:`, error);
+    return;
+  }
+  if (!Array.isArray(items)) {
+    return;
+  }
+  let activeCount = 0;
+  const updatedItems = items.map((item) => {
+    if (!item || typeof item !== 'object') {
+      return item;
+    }
+    if (!isActive && maxAllowed !== null) {
+      if (activeCount < maxAllowed) {
+        activeCount += 1;
+        return { ...item, isActive: true };
+      }
+      return { ...item, isActive: false };
+    }
+    return { ...item, isActive: true };
+  });
+  const hasChanges = updatedItems.some((item, index) => {
+    const previous = items[index];
+    if (!item || typeof item !== 'object' || !previous || typeof previous !== 'object') {
+      return false;
+    }
+    return (item as { isActive?: boolean }).isActive !== (previous as { isActive?: boolean }).isActive;
+  });
+  if (!hasChanges) {
+    return;
+  }
+  await pool.query(
+    'UPDATE kv_store SET value_data = ? WHERE tenant_id = ? AND key_name = ?',
+    [JSON.stringify(updatedItems), tenantId, keyName]
+  );
+}
+
+export async function applyFreePlanDeactivations(tenantId: string): Promise<void> {
+  const freePlan = await getSubscriptionPlan('plan_free');
+  if (!freePlan) {
+    return;
+  }
+  await updatePlanLimitedItems(tenantId, 'children', freePlan.max_children, false);
+  await updatePlanLimitedItems(tenantId, 'chores', freePlan.max_chores, false);
+  await updatePlanLimitedItems(tenantId, 'rewards', freePlan.max_rewards, false);
+}
+
+export async function reactivatePlanItems(tenantId: string): Promise<void> {
+  await updatePlanLimitedItems(tenantId, 'children', null, true);
+  await updatePlanLimitedItems(tenantId, 'chores', null, true);
+  await updatePlanLimitedItems(tenantId, 'rewards', null, true);
+}
+
 // Type for the joined query result with aliased plan columns
 interface SubscriptionWithPlanRow extends TenantSubscription, RowDataPacket {
   plan_id_value: string;
@@ -574,6 +650,7 @@ async function getSubscriptionRowByStripeId(stripeSubscriptionId: string): Promi
 export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Subscription): Promise<void> {
   const stripeSubscriptionId = stripeSubscription.id;
   const status = stripeSubscription.status as SubscriptionStatus;
+  const planId = status === 'canceled' ? 'plan_free' : 'plan_paid';
   const currentPeriodStart = (stripeSubscription.items?.data?.[0]?.current_period_start || 0) * 1000;
   const currentPeriodEnd = (stripeSubscription.items?.data?.[0]?.current_period_end || 0) * 1000;
   const cancelAtPeriodEnd = stripeSubscription.cancel_at_period_end ?? false;
@@ -581,6 +658,12 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
   const stripeCustomerId = typeof stripeSubscription.customer === 'string'
     ? stripeSubscription.customer
     : stripeSubscription.customer?.id ?? null;
+  const [existingRows] = await pool.query<RowDataPacket[]>(
+    'SELECT tenant_id, plan_id FROM subscriptions WHERE stripe_subscription_id = ? LIMIT 1',
+    [stripeSubscriptionId]
+  );
+  const existingTenantId = existingRows[0]?.tenant_id ?? null;
+  const previousPlanId = existingRows[0]?.plan_id ?? null;
 
   const [updateResult] = await pool.query<ResultSetHeader>(
     `UPDATE subscriptions
@@ -593,7 +676,7 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
          stripe_customer_id = COALESCE(stripe_customer_id, ?)
      WHERE stripe_subscription_id = ?`,
     [
-      'plan_paid',
+      planId,
       status,
       currentPeriodStart,
       currentPeriodEnd,
@@ -605,6 +688,14 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
   );
 
   if (updateResult.affectedRows > 0) {
+    if (previousPlanId !== planId && existingTenantId) {
+      if (planId === 'plan_free') {
+        await applyFreePlanDeactivations(existingTenantId);
+      }
+      if (planId === 'plan_paid') {
+        await reactivatePlanItems(existingTenantId);
+      }
+    }
     return;
   }
 
@@ -655,7 +746,7 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
            stripe_subscription_id = ?
        WHERE id = ?`,
       [
-        'plan_paid',
+        planId,
         status,
         currentPeriodStart,
         currentPeriodEnd,
@@ -666,6 +757,12 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
         existingId,
       ]
     );
+    if (planId === 'plan_free') {
+      await applyFreePlanDeactivations(tenantId);
+    }
+    if (planId === 'plan_paid') {
+      await reactivatePlanItems(tenantId);
+    }
     return;
   }
 
@@ -677,7 +774,7 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
     [
       subscriptionId,
       tenantId,
-      'plan_paid',
+      planId,
       status,
       currentPeriodStart,
       currentPeriodEnd,
@@ -687,6 +784,12 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
       canceledAt,
     ]
   );
+  if (planId === 'plan_free') {
+    await applyFreePlanDeactivations(tenantId);
+  }
+  if (planId === 'plan_paid') {
+    await reactivatePlanItems(tenantId);
+  }
 }
 
 export async function syncSubscriptionByStripeId(stripeSubscriptionId: string): Promise<void> {
@@ -970,21 +1073,27 @@ export async function checkPlanLimits(tenantId: string): Promise<{
     [tenantId, 'children']
   );
   const children = childrenRows.length > 0 ? JSON.parse(childrenRows[0].value_data) : [];
-  const childrenCount = Array.isArray(children) ? children.length : 0;
+  const childrenCount = Array.isArray(children)
+    ? children.filter((child) => child?.isActive !== false).length
+    : 0;
   
   const [choresRows] = await pool.query<RowDataPacket[]>(
     'SELECT value_data FROM kv_store WHERE tenant_id = ? AND key_name = ?',
     [tenantId, 'chores']
   );
   const chores = choresRows.length > 0 ? JSON.parse(choresRows[0].value_data) : [];
-  const choresCount = Array.isArray(chores) ? chores.length : 0;
+  const choresCount = Array.isArray(chores)
+    ? chores.filter((chore) => chore?.isActive !== false).length
+    : 0;
   
   const [rewardsRows] = await pool.query<RowDataPacket[]>(
     'SELECT value_data FROM kv_store WHERE tenant_id = ? AND key_name = ?',
     [tenantId, 'rewards']
   );
   const rewards = rewardsRows.length > 0 ? JSON.parse(rewardsRows[0].value_data) : [];
-  const rewardsCount = Array.isArray(rewards) ? rewards.length : 0;
+  const rewardsCount = Array.isArray(rewards)
+    ? rewards.filter((reward) => reward?.isActive !== false).length
+    : 0;
   
   const [devicesRows] = await pool.query<RowDataPacket[]>(
     'SELECT COUNT(*) as count FROM devices WHERE tenant_id = ?',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -239,16 +239,20 @@ function App() {
   const safeReportTemplates = coerceArray<ReportTemplate>(reportTemplates)
   const safePendingDigestItems = coerceArray<any>(pendingDigestItems)
   const safeChildAvailability = coerceArray<ChildAvailabilityEntry>(childAvailability)
+  const activeChildrenList = useMemo(
+    () => safeChildrenList.filter((child) => child.isActive !== false),
+    [safeChildrenList]
+  )
   
   // Filter children based on device restrictions
   // If deviceAllowedChildrenIds is empty array, all children are allowed (default behavior)
   // If it has specific IDs, only those children are allowed
   const filteredChildrenList = useMemo(() => {
     if (deviceIsLinked && deviceAllowedChildrenIds.length > 0) {
-      return safeChildrenList.filter(child => deviceAllowedChildrenIds.includes(child.id))
+      return activeChildrenList.filter(child => deviceAllowedChildrenIds.includes(child.id))
     }
-    return safeChildrenList
-  }, [safeChildrenList, deviceIsLinked, deviceAllowedChildrenIds])
+    return activeChildrenList
+  }, [activeChildrenList, deviceIsLinked, deviceAllowedChildrenIds])
   
   const hasMigratedRewards = useRef(false)
   const hasInitializedCategories = useRef(false)
@@ -511,6 +515,11 @@ function App() {
     })
   }, [safeChores, safeCategories])
 
+  const activeChores = useMemo(
+    () => (migratedChores || []).filter((chore) => chore.isActive !== false),
+    [migratedChores]
+  )
+
   useEffect(() => {
     if (safeAssignments && safeAssignments.length > 0) {
       const oldChores = safeChores
@@ -571,6 +580,11 @@ function App() {
       }
     })
   }, [safeRewards, safeCategories])
+
+  const activeRewards = useMemo(
+    () => (migratedRewards || []).filter((reward) => reward.isActive !== false),
+    [migratedRewards]
+  )
 
   const migratedPurchases = useMemo(() => {
     if (!safePurchases || safePurchases.length === 0) return safePurchases || []
@@ -2154,12 +2168,12 @@ Please log in to ChoreQuest to approve or reject this completion.
             <ViewOnlyBanner tenantId={viewingTenantId} onExit={exitViewMode} />
           )}
           <ParentPanel
-          chores={migratedChores || []}
-          childrenList={safeChildrenList}
+          chores={activeChores}
+          childrenList={activeChildrenList}
           assignments={safeAssignments}
           completions={safeCompletions}
           childPoints={childPoints}
-          rewards={migratedRewards || []}
+          rewards={activeRewards}
           purchases={migratedPurchases}
           history={safeHistory}
           dismissedMissedChores={safeDismissedMissedChores}
@@ -2253,7 +2267,7 @@ Please log in to ChoreQuest to approve or reject this completion.
         showCalendar ? (
           <CalendarView
             child={selectedChild}
-            chores={migratedChores || []}
+            chores={activeChores}
             assignments={safeAssignments}
             completions={safeCompletions}
             categories={safeCategories}
@@ -2277,8 +2291,8 @@ Please log in to ChoreQuest to approve or reject this completion.
         ) : showRewardShop ? (
           <RewardShop
             child={selectedChild}
-            rewards={migratedRewards || []}
-            chores={migratedChores || []}
+            rewards={activeRewards}
+            chores={activeChores}
             completions={safeCompletions}
             purchases={migratedPurchases}
             trackedGoal={safeTrackedGoals.find(g => g.childId === selectedChild.id)}
@@ -2304,13 +2318,13 @@ Please log in to ChoreQuest to approve or reject this completion.
         ) : (
           <ChildChoreView
             child={selectedChild}
-            chores={migratedChores || []}
+            chores={activeChores}
             assignments={safeAssignments}
             completions={safeCompletions}
             totalPoints={childPoints.get(selectedChild.id) || 0}
             celebrationSettings={celebrationSettings || { enabled: true, animations: { confetti: true, fireworks: true, sparkles: true, stars: true, bubbles: true, hearts: true }, showUndoButton: true }}
             trackedGoal={safeTrackedGoals.find(g => g.childId === selectedChild.id)}
-            rewards={safeRewards}
+            rewards={activeRewards}
             categories={safeCategories}
             categoryPoints={childCategoryPoints.get(selectedChild.id)}
             availableCategoryPoints={childAvailableCategoryPoints.get(selectedChild.id)}
@@ -2336,7 +2350,7 @@ Please log in to ChoreQuest to approve or reject this completion.
         )
       ) : (
         <>
-          {safeChildrenList.length === 0 ? (
+          {activeChildrenList.length === 0 ? (
             <div className="h-full flex items-center justify-center p-8">
               <div className="text-center max-w-md">
                 <h1 className="text-4xl font-fredoka font-bold mb-4">
@@ -2361,11 +2375,11 @@ Please log in to ChoreQuest to approve or reject this completion.
               childPoints={childPoints}
               pendingPurchasesCount={pendingPurchasesCount}
               trackedGoals={safeTrackedGoals}
-              rewards={safeRewards}
+              rewards={activeRewards}
               categoryPoints={childCategoryPoints}
               categories={safeCategories}
               assignments={safeAssignments}
-              chores={migratedChores || []}
+              chores={activeChores}
               completions={safeCompletions}
               childAvailability={safeChildAvailability}
               weatherSettings={weatherSettings || { enabled: false, location: '', latitude: null, longitude: null, temperatureUnit: 'auto' }}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -134,6 +134,7 @@ export interface Chore {
   speakDescription?: boolean
   inactiveOnSchoolHolidays?: boolean
   onlyOnSchoolHolidays?: boolean
+  isActive?: boolean
   rotationConfig?: RotationConfig
   emoji?: string
 }
@@ -146,6 +147,7 @@ export interface Child {
   avatarColor: string
   totalPoints: number
   createdAt: number
+  isActive?: boolean
   icsUrl?: string
   calendarLastRefresh?: number
   calendarAutoRefresh?: boolean
@@ -247,6 +249,7 @@ export interface Reward {
   imageEmoji: string
   createdAt: number
   categoryIds: string[]
+  isActive?: boolean
   costOverrides?: RewardCostOverride[]
   requirements?: RewardRequirement[]
   purchaseLimit?: PurchaseLimit


### PR DESCRIPTION
### Motivation
- Prevent tenants from exceeding free plan limits by automatically deactivating Children/Chores/Rewards when a subscription moves from Paid to Free. 
- Preserve data instead of deleting items so a tenant can re-subscribe and restore access later. 
- Ensure the UI and plan limit enforcement only consider active items so counts remain consistent with what users can access. 

### Description
- Added server helpers `updatePlanLimitedItems`, `applyFreePlanDeactivations`, and `reactivatePlanItems` to mark items in `kv_store` as `isActive: false/true` and persist changes rather than deleting data. 
- Updated `upsertSubscriptionFromStripe` to derive `planId` from Stripe status and call the deactivation/reactivation helpers when subscription plan transitions occur. 
- Updated admin subscription update route to trigger deactivation/reactivation when an admin changes a tenant's plan. 
- Modified `checkPlanLimits` to count only items with `isActive !== false` when enforcing plan limits. 
- Introduced `isActive?: boolean` on `Child`, `Chore`, and `Reward` types and updated the client (`src/App.tsx`) to filter out inactive items via `activeChildrenList`, `activeChores`, and `activeRewards` so deactivated items are hidden from parent/child views. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985403562e0833288d8f949586166e3)