### PR TITLE
Fix subscription upsert variable reuse

### DIFF
--- a/server/src/services/subscription.ts
+++ b/server/src/services/subscription.ts
@@ -727,11 +727,11 @@ export async function upsertSubscriptionFromStripe(stripeSubscription: Stripe.Su
     return;
   }
 
-  const [existingRows] = await pool.query<RowDataPacket[]>(
+  const [existingTenantRows] = await pool.query<RowDataPacket[]>(
     'SELECT id FROM subscriptions WHERE tenant_id = ? ORDER BY created_at DESC LIMIT 1',
     [tenantId]
   );
-  const existingId = existingRows[0]?.id ?? null;
+  const existingId = existingTenantRows[0]?.id ?? null;
 
   if (existingId) {
     await pool.query<ResultSetHeader>(


### PR DESCRIPTION
### Motivation
- Build was failing with TypeScript error TS2451 ("Cannot redeclare block-scoped variable 'existingRows'") during `npm run build` in Docker due to reusing the `existingRows` variable name in `upsertSubscriptionFromStripe`.

### Description
- Rename the tenant lookup result from `existingRows` to `existingTenantRows` and update the subsequent reference to `existingId` in `server/src/services/subscription.ts` to avoid the redeclaration.

### Testing
- No automated tests were run after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69854565a8508332b3266cdbe3a7e144)