### PR TITLE
Add child-friendly wallpaper themes with per-device controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,8 @@ import {
   ChildAvailabilityEntry,
   SchoolHolidayCountdownSettings,
   GettingStartedState,
+  WallpaperSettings,
+  DeviceWallpaperSettingsMap,
 } from '@/lib/types'
 import { getChildTotalPoints, getChildAvailablePoints, canPurchaseReward, DEFAULT_CATEGORIES, getChildPointsByCategory, isRewardActive, getChildAvailablePointsByCategory, areAllCategoryChoresCompleted, hasBonusBeenClaimedToday, getUserIPAddress, isIPAllowed, isPrerequisiteCategoryCompleted, getUpdatedRotationState } from '@/lib/helpers'
 import { DEFAULT_REPORT_TEMPLATES } from '@/lib/reportHelpers'
@@ -152,6 +154,14 @@ function App() {
     temperatureUnit: 'auto',
     seasonalThemesEnabled: false,
   })
+  const [wallpaperSettings, setWallpaperSettings] = useKV<WallpaperSettings>('wallpaper-settings', {
+    enabled: true,
+    weatherWallpapersEnabled: true,
+    nonWeatherWallpapersEnabled: true,
+    animationsEnabled: true,
+    defaultMode: 'weather',
+  })
+  const [deviceWallpaperSettings, setDeviceWallpaperSettings] = useKV<DeviceWallpaperSettingsMap>('device-wallpaper-settings', {})
   const [smtpEnabled, setSmtpEnabled] = useState(false)
   const [emailAlertSettings, setEmailAlertSettings] = useKV<EmailAlertSettings>('email-alert-settings', {
     rewardPurchaseAlerts: false,
@@ -2203,6 +2213,8 @@ Please log in to ChoreQuest to approve or reject this completion.
           childAvailability={safeChildAvailability}
           schoolHolidayCountdownSettings={schoolHolidayCountdownSettings || { enabled: false, countdownMode: 'calendar-days', showRemainingDays: true }}
           gettingStartedState={gettingStartedState}
+          wallpaperSettings={wallpaperSettings || { enabled: true, weatherWallpapersEnabled: true, nonWeatherWallpapersEnabled: true, animationsEnabled: true, defaultMode: 'weather' }}
+          deviceWallpaperSettings={deviceWallpaperSettings || {}}
           onAddChore={handleAddChore}
           onEditChore={handleEditChore}
           onDeleteChore={handleDeleteChore}
@@ -2245,6 +2257,8 @@ Please log in to ChoreQuest to approve or reject this completion.
           onUpdateHideChildrenWithNoActivity={(value) => setHideChildrenWithNoActivity(value)}
           onUpdateBlockParentModeOnLinkedDevices={(value: boolean) => setBlockParentModeOnLinkedDevices(value)}
           blockParentModeOnLinkedDevices={blockParentModeOnLinkedDevices}
+          onUpdateWallpaperSettings={(settings) => setWallpaperSettings(settings)}
+          onUpdateDeviceWallpaperSettings={(settings) => setDeviceWallpaperSettings(settings)}
           onAddReportTemplate={handleAddReportTemplate}
           onEditReportTemplate={handleEditReportTemplate}
           onDeleteReportTemplate={handleDeleteReportTemplate}
@@ -2331,6 +2345,9 @@ Please log in to ChoreQuest to approve or reject this completion.
             currentWeather={currentWeather}
             schoolHolidays={schoolHolidays || []}
             childAvailability={safeChildAvailability}
+            wallpaperSettings={wallpaperSettings || { enabled: true, weatherWallpapersEnabled: true, nonWeatherWallpapersEnabled: true, animationsEnabled: true, defaultMode: 'weather' }}
+            deviceWallpaperSettings={deviceWallpaperSettings || {}}
+            currentDeviceId={getDeviceId()}
             onComplete={(choreId, timeOfDay) => handleCompleteChore(selectedChild.id, choreId, timeOfDay)}
             onUndo={(choreId, timeOfDay) => handleUndoChore(selectedChild.id, choreId, timeOfDay)}
             onBack={() => {
@@ -2392,6 +2409,9 @@ Please log in to ChoreQuest to approve or reject this completion.
               blockParentModeOnLinkedDevices={blockParentModeOnLinkedDevices}
               deviceRegistrationComplete={deviceRegistrationComplete}
               pushNotificationSettings={pushNotificationSettings || DEFAULT_PUSH_NOTIFICATION_SETTINGS}
+              wallpaperSettings={wallpaperSettings || { enabled: true, weatherWallpapersEnabled: true, nonWeatherWallpapersEnabled: true, animationsEnabled: true, defaultMode: 'weather' }}
+              deviceWallpaperSettings={deviceWallpaperSettings || {}}
+              currentWeather={currentWeather}
               onOpenSettings={handleRequestParentMode}
               onSelect={setSelectedChild}
               onParentMode={handleRequestParentMode}

--- a/src/components/ChildChoreView.tsx
+++ b/src/components/ChildChoreView.tsx
@@ -5,13 +5,14 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { CheckCircle, Circle, Calendar, Star, ShoppingCart, SunHorizon, MoonStars, Warning, Users, Trophy, ArrowCounterClockwise, Clock, Timer, ClockClockwise, ChartLine, Lock } from '@phosphor-icons/react'
-import { Child, Chore, ChoreAssignment, ChoreCompletion, CelebrationSettings, CelebrationAnimation, Reward, GoalTracker, Category, WeatherData, SchoolHoliday, ChildAvailabilityEntry } from '@/lib/types'
+import { Child, Chore, ChoreAssignment, ChoreCompletion, CelebrationSettings, CelebrationAnimation, Reward, GoalTracker, Category, WeatherData, SchoolHoliday, ChildAvailabilityEntry, WallpaperSettings, DeviceWallpaperSettingsMap } from '@/lib/types'
 import { isChoreCompleted, isChoreActive, isChoreAvailableNow, isChoreMissed, getCurrentTimeOfDay, isChoreCompletedForTimeOfDay, getChorePointsForChild, getChoreCategoryPointsForChild, sortChoresByDesiredTime, getRandomCelebrationAnimation, getTimeWindowStatus, formatTime12Hour, getRewardCostForChild, formatDuration, getCategoryCompletionProgress, getShareableChoreCompletionCount, isShareableChoreFullyCompleted, hasChildCompletedShareableChore, getInitialsFromName, isPrerequisiteCategoryCompleted, isChoreActiveTodayWithHolidays, isChildAvailableForTimeOfDay, isRotationalChoreVisibleToChild } from '@/lib/helpers'
 import { shouldShowChore } from '@/lib/weatherChoreHelper'
 import { ChoreCompletionCelebration } from './Celebration'
 import { GoalProgress } from './GoalProgress'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { OnThisDay } from './OnThisDay'
+import { WallpaperSurface } from './WallpaperSurface'
 
 interface ChildChoreViewProps {
   child: Child
@@ -36,6 +37,9 @@ interface ChildChoreViewProps {
   currentWeather?: WeatherData | null
   schoolHolidays?: SchoolHoliday[]
   childAvailability?: ChildAvailabilityEntry[]
+  wallpaperSettings: WallpaperSettings
+  deviceWallpaperSettings: DeviceWallpaperSettingsMap
+  currentDeviceId: string
 }
 
 export function ChildChoreView({
@@ -61,6 +65,9 @@ export function ChildChoreView({
   currentWeather,
   schoolHolidays = [],
   childAvailability = [],
+  wallpaperSettings,
+  deviceWallpaperSettings,
+  currentDeviceId,
 }: ChildChoreViewProps) {
   const [celebrating, setCelebrating] = useState<{ points: number; animation: CelebrationAnimation } | null>(null)
 
@@ -391,7 +398,13 @@ export function ChildChoreView({
   }, [categoriesWithBonuses, child.id, assignments, chores, completions])
 
   return (
-    <div className="h-full overflow-y-auto bg-gradient-to-br from-primary/10 via-secondary/20 to-accent/10 p-8">
+    <WallpaperSurface
+      wallpaperSettings={wallpaperSettings}
+      deviceWallpaperSettings={deviceWallpaperSettings}
+      currentWeather={currentWeather || null}
+      currentDeviceId={currentDeviceId}
+      contentClassName="p-8"
+    >
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center justify-between mb-8">
           <div className="flex items-center gap-4">
@@ -1086,6 +1099,6 @@ export function ChildChoreView({
           />
         )}
       </AnimatePresence>
-    </div>
+    </WallpaperSurface>
   )
 }

--- a/src/components/ChildSelector.tsx
+++ b/src/components/ChildSelector.tsx
@@ -6,7 +6,7 @@ import { Progress } from '@/components/ui/progress'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Gear, Trophy, Clock, SpeakerHigh, Fingerprint } from '@phosphor-icons/react'
-import { Child, GoalTracker, Reward, Category, ChoreAssignment, Chore, ChoreCompletion, WeatherSettings, SpeechSettings, BiometricSettings, SchoolHoliday, SchoolHolidayCountdownSettings, ChildAvailabilityEntry, PushNotificationSettings } from '@/lib/types'
+import { Child, GoalTracker, Reward, Category, ChoreAssignment, Chore, ChoreCompletion, WeatherSettings, SpeechSettings, BiometricSettings, SchoolHoliday, SchoolHolidayCountdownSettings, ChildAvailabilityEntry, PushNotificationSettings, WallpaperSettings, DeviceWallpaperSettingsMap, WeatherData } from '@/lib/types'
 import { getRewardCostForChild, getNextUpcomingChore, formatTime12Hour, formatDuration, getInitialsFromName, hasChildActivity, getWeeklyChoreMessage } from '@/lib/helpers'
 import { WeatherDisplay } from '@/components/WeatherDisplay'
 import { SchoolHolidayCountdownCard } from '@/components/SchoolHolidayCountdownCard'
@@ -15,6 +15,7 @@ import { isStandalone } from '@/lib/pwaHelper'
 import { fetchICSFeed, getICSEventsForToday } from '@/lib/icsHelper'
 import { getDeviceId } from '@/lib/deviceHelper'
 import { isPushNotificationSupported } from '@/lib/pushNotificationHelper'
+import { WallpaperSurface } from '@/components/WallpaperSurface'
 
 const NOTIFICATION_SETUP_DISMISSED_KEY = 'notification-setup-dismissed'
 
@@ -43,6 +44,9 @@ interface ChildSelectorProps {
   deviceRegistrationComplete?: boolean
   pushNotificationSettings?: PushNotificationSettings
   onOpenSettings?: () => void
+  wallpaperSettings: WallpaperSettings
+  deviceWallpaperSettings: DeviceWallpaperSettingsMap
+  currentWeather: WeatherData | null
 }
 
 export function ChildSelector({ 
@@ -70,6 +74,9 @@ export function ChildSelector({
   deviceRegistrationComplete = false,
   pushNotificationSettings,
   onOpenSettings,
+  wallpaperSettings,
+  deviceWallpaperSettings,
+  currentWeather,
 }: ChildSelectorProps) {
   const [currentDateTime, setCurrentDateTime] = useState(new Date())
   const [isSpeaking, setIsSpeaking] = useState<string | null>(null)
@@ -225,7 +232,13 @@ export function ChildSelector({
   }
 
   return (
-    <div className="h-full overflow-y-auto bg-gradient-to-br from-primary/10 via-secondary/20 to-accent/10 p-8">
+    <WallpaperSurface
+      wallpaperSettings={wallpaperSettings}
+      deviceWallpaperSettings={deviceWallpaperSettings}
+      currentWeather={currentWeather || null}
+      currentDeviceId={getDeviceId()}
+      contentClassName="p-8"
+    >
       <div className="max-w-4xl mx-auto">
         <motion.h1
           initial={{ opacity: 0, y: -20 }}
@@ -458,6 +471,6 @@ export function ChildSelector({
           )}
         </div>
       </div>
-    </div>
+    </WallpaperSurface>
   )
 }

--- a/src/components/ParentPanel.tsx
+++ b/src/components/ParentPanel.tsx
@@ -13,10 +13,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { Plus, Package, Check, Sparkle, Users, ListChecks, Gift, X, Gear, ClockCounterClockwise, Warning, ClipboardText, Shield, Envelope, FileText, SpeakerHigh, Bell, House, Pulse, FolderUser, Devices, RocketLaunch, Question, CreditCard } from '@phosphor-icons/react'
+import { Plus, Package, Check, Sparkle, Users, ListChecks, Gift, X, Gear, ClockCounterClockwise, Warning, ClipboardText, Shield, Envelope, FileText, SpeakerHigh, Bell, House, Pulse, FolderUser, Devices, RocketLaunch, Question, CreditCard, ImageSquare } from '@phosphor-icons/react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useSubscription } from '@/hooks/use-subscription'
-import { Child, Chore, ChoreAssignment, Reward, RewardPurchase, ChoreCompletion, ChoreHistoryEvent, MissedChore, CelebrationSettings, Category, DayOfWeek, RepeatPattern, BiometricSettings, IPRestrictionSettings, IPAccessAttempt, WeeklyReportSettings, CategoryBonusCompletion, ReportTemplate, WeatherSettings, PointSwap, EmailAlertSettings, WeatherData, SpeechSettings, PushNotificationSettings, SchoolHoliday, SchoolHolidayCountdownSettings, ChildAvailabilityEntry, EmailAlertSettingsMap, WeeklyReportSettingsMap, GettingStartedState } from '@/lib/types'
+import { Child, Chore, ChoreAssignment, Reward, RewardPurchase, ChoreCompletion, ChoreHistoryEvent, MissedChore, CelebrationSettings, Category, DayOfWeek, RepeatPattern, BiometricSettings, IPRestrictionSettings, IPAccessAttempt, WeeklyReportSettings, CategoryBonusCompletion, ReportTemplate, WeatherSettings, PointSwap, EmailAlertSettings, WeatherData, SpeechSettings, PushNotificationSettings, SchoolHoliday, SchoolHolidayCountdownSettings, ChildAvailabilityEntry, EmailAlertSettingsMap, WeeklyReportSettingsMap, GettingStartedState, WallpaperSettings, DeviceWallpaperSettingsMap } from '@/lib/types'
 import {
   DndContext,
   closestCenter,
@@ -65,6 +65,7 @@ import { GettingStartedMenu } from './GettingStartedMenu'
 import { HelpMenu } from './HelpMenu'
 import { DeviceSettings } from './DeviceSettings'
 import { SubscriptionSettings } from './SubscriptionSettings'
+import { WallpaperSettingsPanel } from './WallpaperSettingsPanel'
 import { generateICSFeed, downloadICSFile } from '@/lib/icsHelper'
 import { isChoreActive, isChoreActiveToday, isChildAvailableForTimeOfDay } from '@/lib/helpers'
 import { toast } from 'sonner'
@@ -154,6 +155,8 @@ interface ParentPanelProps {
   childAvailability: ChildAvailabilityEntry[]
   schoolHolidayCountdownSettings: SchoolHolidayCountdownSettings
   gettingStartedState: GettingStartedState
+  wallpaperSettings: WallpaperSettings
+  deviceWallpaperSettings: DeviceWallpaperSettingsMap
   onAddChore: (chore: Omit<Chore, 'id' | 'createdAt'>) => void
   onEditChore: (id: string, chore: Omit<Chore, 'id' | 'createdAt'>) => void
   onDeleteChore: (id: string) => void
@@ -203,6 +206,8 @@ interface ParentPanelProps {
   onUpdateSpeechSettings: (settings: SpeechSettings) => void
   onUpdateHideChildrenWithNoActivity: (value: boolean) => void
   onUpdateBlockParentModeOnLinkedDevices: (value: boolean) => void
+  onUpdateWallpaperSettings: (settings: WallpaperSettings) => void
+  onUpdateDeviceWallpaperSettings: (settings: DeviceWallpaperSettingsMap) => void
   onAddReportTemplate: (templateData: Omit<ReportTemplate, 'id' | 'createdAt'>) => void
   onEditReportTemplate: (id: string, templateData: Omit<ReportTemplate, 'id' | 'createdAt'>) => void
   onDeleteReportTemplate: (id: string) => void
@@ -289,6 +294,8 @@ export function ParentPanel({
   onUpdateHideChildrenWithNoActivity,
   blockParentModeOnLinkedDevices,
   onUpdateBlockParentModeOnLinkedDevices,
+  onUpdateWallpaperSettings,
+  onUpdateDeviceWallpaperSettings,
   onAddReportTemplate,
   onEditReportTemplate,
   onDeleteReportTemplate,
@@ -296,6 +303,8 @@ export function ParentPanel({
   childAvailability,
   schoolHolidayCountdownSettings,
   gettingStartedState,
+  wallpaperSettings,
+  deviceWallpaperSettings,
   onAddSchoolHoliday,
   onEditSchoolHoliday,
   onDeleteSchoolHoliday,
@@ -1132,6 +1141,10 @@ export function ParentPanel({
                 <Gear className="h-4 w-4 mr-2" />
                 Settings
               </TabsTrigger>
+              <TabsTrigger value="wallpapers">
+                <ImageSquare className="h-4 w-4 mr-2" />
+                Wallpapers
+              </TabsTrigger>
               <TabsTrigger value="notifications">
                 <Bell className="h-4 w-4 mr-2" />
                 Notifications
@@ -1185,6 +1198,15 @@ export function ParentPanel({
                 onUpdateEmailAlertSettingsMap={onUpdateEmailAlertSettingsMap}
                 onUpdateWeeklyReportSettingsMap={onUpdateWeeklyReportSettingsMap}
                 showOnlyNotifications={true}
+              />
+            </TabsContent>
+
+            <TabsContent value="wallpapers" className="space-y-4">
+              <WallpaperSettingsPanel
+                wallpaperSettings={wallpaperSettings}
+                deviceWallpaperSettings={deviceWallpaperSettings}
+                onUpdateWallpaperSettings={onUpdateWallpaperSettings}
+                onUpdateDeviceWallpaperSettings={onUpdateDeviceWallpaperSettings}
               />
             </TabsContent>
 

--- a/src/components/WallpaperSettingsPanel.tsx
+++ b/src/components/WallpaperSettingsPanel.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Monitor, ImageSquare } from '@phosphor-icons/react'
+import { useAuth } from '@/contexts/AuthContext'
+import { getLinkedDevices, getDeviceGuid, DeviceInfo } from '@/lib/deviceHelper'
+import type { DeviceWallpaperSettingsMap, WallpaperMode, WallpaperSettings } from '@/lib/types'
+import { nonWeatherWallpaperCount, weatherWallpaperCountByType } from '@/lib/wallpaperLibrary'
+import { toast } from 'sonner'
+
+interface DeviceSummary {
+  id: string
+  deviceGuid: string
+  deviceName: string | null
+  deviceInfo: DeviceInfo
+}
+
+interface WallpaperSettingsPanelProps {
+  wallpaperSettings: WallpaperSettings
+  deviceWallpaperSettings: DeviceWallpaperSettingsMap
+  onUpdateWallpaperSettings: (settings: WallpaperSettings) => void
+  onUpdateDeviceWallpaperSettings: (settings: DeviceWallpaperSettingsMap) => void
+}
+
+const getDeviceLabel = (device: DeviceSummary) => {
+  if (device.deviceName) return device.deviceName
+  const userAgent = device.deviceInfo?.userAgent || 'Unknown Device'
+  let browser = 'Browser'
+  let os = device.deviceInfo?.platform || 'OS'
+
+  if (userAgent.includes('Chrome')) browser = 'Chrome'
+  else if (userAgent.includes('Firefox')) browser = 'Firefox'
+  else if (userAgent.includes('Safari')) browser = 'Safari'
+  else if (userAgent.includes('Edge')) browser = 'Edge'
+
+  if (userAgent.includes('Windows')) os = 'Windows'
+  else if (userAgent.includes('Mac')) os = 'macOS'
+  else if (userAgent.includes('Linux')) os = 'Linux'
+  else if (userAgent.includes('Android')) os = 'Android'
+  else if (userAgent.includes('iOS') || userAgent.includes('iPhone') || userAgent.includes('iPad')) os = 'iOS'
+
+  return `${browser} on ${os}`
+}
+
+export function WallpaperSettingsPanel({
+  wallpaperSettings,
+  deviceWallpaperSettings,
+  onUpdateWallpaperSettings,
+  onUpdateDeviceWallpaperSettings,
+}: WallpaperSettingsPanelProps) {
+  const { token } = useAuth()
+  const [devices, setDevices] = useState<DeviceSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const currentDeviceGuid = getDeviceGuid()
+
+  useEffect(() => {
+    if (!token) {
+      setDevices([])
+      return
+    }
+
+    const loadDevices = async () => {
+      setLoading(true)
+      try {
+        const linkedDevices = await getLinkedDevices(token)
+        setDevices(
+          linkedDevices.map((device) => ({
+            id: device.id,
+            deviceGuid: device.deviceGuid,
+            deviceName: device.deviceName,
+            deviceInfo: device.deviceInfo,
+          }))
+        )
+      } catch (error) {
+        console.error('Error loading linked devices:', error)
+        toast.error('Failed to load linked devices')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadDevices()
+  }, [token])
+
+  const allDevices = useMemo(() => {
+    const currentDevice: DeviceSummary = {
+      id: currentDeviceGuid,
+      deviceGuid: currentDeviceGuid,
+      deviceName: 'This device',
+      deviceInfo: { userAgent: navigator.userAgent, platform: navigator.platform, mobile: false, timestamp: '' },
+    }
+
+    const filtered = devices.filter((device) => device.deviceGuid !== currentDeviceGuid)
+    return [currentDevice, ...filtered]
+  }, [devices, currentDeviceGuid])
+
+  const handleModeChange = (deviceId: string, mode: WallpaperMode) => {
+    onUpdateDeviceWallpaperSettings({
+      ...deviceWallpaperSettings,
+      [deviceId]: { mode },
+    })
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ImageSquare className="h-5 w-5" />
+          Wallpapers
+        </CardTitle>
+        <CardDescription>
+          Manage child-friendly backgrounds for the main child views.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <Label className="text-base">Enable Wallpapers</Label>
+            <p className="text-sm text-muted-foreground">
+              Turn on playful wallpapers for the child dashboard and chore pages.
+            </p>
+          </div>
+          <Switch
+            checked={wallpaperSettings.enabled}
+            onCheckedChange={(enabled) => onUpdateWallpaperSettings({ ...wallpaperSettings, enabled })}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <Label className="text-base">Weather Themes</Label>
+              <p className="text-sm text-muted-foreground">
+                Use {Object.values(weatherWallpaperCountByType).reduce((sum, count) => sum + count, 0)} weather-inspired wallpapers.
+              </p>
+            </div>
+            <Switch
+              checked={wallpaperSettings.weatherWallpapersEnabled}
+              onCheckedChange={(enabled) =>
+                onUpdateWallpaperSettings({
+                  ...wallpaperSettings,
+                  weatherWallpapersEnabled: enabled,
+                })
+              }
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <Label className="text-base">Non-Weather Themes</Label>
+              <p className="text-sm text-muted-foreground">
+                Use {nonWeatherWallpaperCount} playful wallpapers even without weather data.
+              </p>
+            </div>
+            <Switch
+              checked={wallpaperSettings.nonWeatherWallpapersEnabled}
+              onCheckedChange={(enabled) =>
+                onUpdateWallpaperSettings({
+                  ...wallpaperSettings,
+                  nonWeatherWallpapersEnabled: enabled,
+                })
+              }
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <Label className="text-base">Background Animations</Label>
+            <p className="text-sm text-muted-foreground">
+              Add gentle movement to wallpaper patterns.
+            </p>
+          </div>
+          <Switch
+            checked={wallpaperSettings.animationsEnabled}
+            onCheckedChange={(enabled) =>
+              onUpdateWallpaperSettings({
+                ...wallpaperSettings,
+                animationsEnabled: enabled,
+              })
+            }
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-base">Default Theme Mode</Label>
+          <Select
+            value={wallpaperSettings.defaultMode}
+            onValueChange={(value) =>
+              onUpdateWallpaperSettings({
+                ...wallpaperSettings,
+                defaultMode: value as WallpaperMode,
+              })
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select wallpaper mode" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="weather">Weather themed</SelectItem>
+              <SelectItem value="non-weather">Non-weather themed</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Monitor className="h-4 w-4" />
+            <Label className="text-base">Per-Device Wallpaper Mode</Label>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Choose weather or non-weather wallpapers for each linked device. All wallpapers are enabled by default.
+          </p>
+          <div className="space-y-3">
+            {allDevices.map((device) => {
+              const deviceMode = deviceWallpaperSettings[device.deviceGuid]?.mode || wallpaperSettings.defaultMode
+              return (
+                <div
+                  key={device.deviceGuid}
+                  className="flex flex-col gap-2 rounded-lg border border-border/70 p-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <p className="font-medium">{getDeviceLabel(device)}</p>
+                    <p className="text-xs text-muted-foreground">{device.deviceGuid}</p>
+                  </div>
+                  <Select
+                    value={deviceMode}
+                    onValueChange={(value) => handleModeChange(device.deviceGuid, value as WallpaperMode)}
+                    disabled={loading}
+                  >
+                    <SelectTrigger className="w-full md:w-56">
+                      <SelectValue placeholder="Choose mode" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="weather">Weather themed</SelectItem>
+                      <SelectItem value="non-weather">Non-weather themed</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )
+            })}
+            {allDevices.length === 0 && (
+              <p className="text-sm text-muted-foreground">No linked devices found.</p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/WallpaperSurface.tsx
+++ b/src/components/WallpaperSurface.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from 'react'
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import type { DeviceWallpaperSettingsMap, WallpaperSettings, WeatherData, WallpaperMode } from '@/lib/types'
+import { getDeviceWallpaperMode, getWallpaperSelection } from '@/lib/wallpaperLibrary'
+
+interface WallpaperSurfaceProps {
+  children: ReactNode
+  className?: string
+  contentClassName?: string
+  wallpaperSettings: WallpaperSettings
+  deviceWallpaperSettings: DeviceWallpaperSettingsMap
+  currentWeather: WeatherData | null
+  currentDeviceId: string
+  fallbackClassName?: string
+}
+
+export function WallpaperSurface({
+  children,
+  className,
+  contentClassName,
+  wallpaperSettings,
+  deviceWallpaperSettings,
+  currentWeather,
+  currentDeviceId,
+  fallbackClassName = 'bg-gradient-to-br from-primary/10 via-secondary/20 to-accent/10',
+}: WallpaperSurfaceProps) {
+  const deviceMode = getDeviceWallpaperMode({
+    settings: wallpaperSettings,
+    deviceMode: deviceWallpaperSettings[currentDeviceId]?.mode as WallpaperMode | undefined,
+  })
+
+  const wallpaperSelection = useMemo(
+    () =>
+      getWallpaperSelection({
+        settings: wallpaperSettings,
+        deviceMode,
+        weather: currentWeather,
+        seedKey: `${currentDeviceId}-${new Date().toISOString().slice(0, 10)}`,
+      }),
+    [wallpaperSettings, deviceMode, currentWeather, currentDeviceId]
+  )
+
+  const wrapperClassName = cn(
+    'relative h-full overflow-y-auto',
+    wallpaperSelection ? 'wallpaper-surface' : fallbackClassName,
+    wallpaperSelection && wallpaperSettings.animationsEnabled ? 'wallpaper-animate' : '',
+    className
+  )
+
+  return (
+    <div className={wrapperClassName} style={wallpaperSelection?.style}>
+      {wallpaperSelection && (
+        <div
+          className={cn(
+            'pointer-events-none absolute inset-0 wallpaper-overlay',
+            wallpaperSettings.animationsEnabled ? 'wallpaper-overlay-animate' : ''
+          )}
+          aria-hidden="true"
+        />
+      )}
+      <div className={cn('relative z-10', contentClassName)}>{children}</div>
+    </div>
+  )
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -536,6 +536,24 @@ export interface ReportSummary {
 
 export type TemperatureUnit = 'auto' | 'celsius' | 'fahrenheit'
 
+export type WallpaperMode = 'weather' | 'non-weather'
+
+export interface WallpaperSettings {
+  enabled: boolean
+  weatherWallpapersEnabled: boolean
+  nonWeatherWallpapersEnabled: boolean
+  animationsEnabled: boolean
+  defaultMode: WallpaperMode
+}
+
+export interface DeviceWallpaperSettings {
+  mode: WallpaperMode
+}
+
+export interface DeviceWallpaperSettingsMap {
+  [deviceId: string]: DeviceWallpaperSettings
+}
+
 export interface WeatherSettings {
   enabled: boolean
   location: string

--- a/src/lib/wallpaperLibrary.ts
+++ b/src/lib/wallpaperLibrary.ts
@@ -1,0 +1,735 @@
+import type { CSSProperties } from 'react'
+import type { WeatherData, WallpaperMode, WallpaperSettings } from '@/lib/types'
+
+export type WeatherWallpaperType =
+  | 'clear'
+  | 'partly-cloudy'
+  | 'cloudy'
+  | 'fog'
+  | 'drizzle'
+  | 'rain'
+  | 'snow'
+  | 'thunder'
+
+export interface WallpaperDefinition {
+  id: string
+  label: string
+  category: 'weather' | 'non-weather'
+  weatherType?: WeatherWallpaperType
+  gradient: string
+  pattern: string
+  patternSize?: string
+  accentPattern?: string
+  accentSize?: string
+}
+
+export interface WallpaperSelection {
+  id: string
+  label: string
+  category: 'weather' | 'non-weather'
+  style: CSSProperties
+}
+
+const toDataUri = (svg: string) => `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+
+const createSunPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <circle cx="60" cy="60" r="16" fill="${color}" fill-opacity="0.35" />
+      <circle cx="140" cy="140" r="12" fill="${accent}" fill-opacity="0.25" />
+      <g stroke="${color}" stroke-opacity="0.35" stroke-width="4" stroke-linecap="round">
+        <line x1="60" y1="25" x2="60" y2="10" />
+        <line x1="60" y1="95" x2="60" y2="110" />
+        <line x1="25" y1="60" x2="10" y2="60" />
+        <line x1="95" y1="60" x2="110" y2="60" />
+        <line x1="35" y1="35" x2="22" y2="22" />
+        <line x1="85" y1="35" x2="98" y2="22" />
+        <line x1="35" y1="85" x2="22" y2="98" />
+        <line x1="85" y1="85" x2="98" y2="98" />
+      </g>
+    </svg>
+  `)
+
+const createCloudPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g fill="${color}" fill-opacity="0.28">
+        <circle cx="60" cy="70" r="18" />
+        <circle cx="80" cy="60" r="22" />
+        <circle cx="100" cy="70" r="16" />
+        <rect x="50" y="70" width="70" height="20" rx="10" />
+      </g>
+      <g fill="${accent}" fill-opacity="0.2">
+        <circle cx="130" cy="130" r="18" />
+        <circle cx="150" cy="120" r="22" />
+        <circle cx="170" cy="130" r="16" />
+        <rect x="120" y="130" width="70" height="20" rx="10" />
+      </g>
+    </svg>
+  `)
+
+const createFogPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g stroke="${color}" stroke-opacity="0.3" stroke-width="6" stroke-linecap="round">
+        <line x1="20" y1="60" x2="180" y2="60" />
+        <line x1="10" y1="100" x2="160" y2="100" />
+        <line x1="30" y1="140" x2="190" y2="140" />
+      </g>
+      <g stroke="${accent}" stroke-opacity="0.2" stroke-width="4" stroke-linecap="round">
+        <line x1="0" y1="80" x2="140" y2="80" />
+        <line x1="50" y1="120" x2="200" y2="120" />
+      </g>
+    </svg>
+  `)
+
+const createDrizzlePattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g stroke="${color}" stroke-opacity="0.35" stroke-width="4" stroke-linecap="round">
+        <line x1="40" y1="40" x2="30" y2="70" />
+        <line x1="90" y1="30" x2="80" y2="60" />
+        <line x1="140" y1="50" x2="130" y2="80" />
+        <line x1="180" y1="30" x2="170" y2="60" />
+      </g>
+      <g stroke="${accent}" stroke-opacity="0.25" stroke-width="3" stroke-linecap="round">
+        <line x1="20" y1="110" x2="10" y2="140" />
+        <line x1="80" y1="120" x2="70" y2="150" />
+        <line x1="150" y1="110" x2="140" y2="140" />
+      </g>
+    </svg>
+  `)
+
+const createRainPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g stroke="${color}" stroke-opacity="0.4" stroke-width="5" stroke-linecap="round">
+        <line x1="30" y1="30" x2="15" y2="70" />
+        <line x1="70" y1="20" x2="55" y2="60" />
+        <line x1="110" y1="35" x2="95" y2="75" />
+        <line x1="150" y1="25" x2="135" y2="65" />
+        <line x1="185" y1="40" x2="170" y2="80" />
+      </g>
+      <g stroke="${accent}" stroke-opacity="0.3" stroke-width="4" stroke-linecap="round">
+        <line x1="50" y1="110" x2="35" y2="150" />
+        <line x1="95" y1="120" x2="80" y2="160" />
+        <line x1="140" y1="110" x2="125" y2="150" />
+        <line x1="180" y1="120" x2="165" y2="160" />
+      </g>
+    </svg>
+  `)
+
+const createSnowPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g fill="${color}" fill-opacity="0.35">
+        <circle cx="30" cy="40" r="5" />
+        <circle cx="80" cy="30" r="6" />
+        <circle cx="130" cy="50" r="4" />
+        <circle cx="170" cy="30" r="5" />
+        <circle cx="50" cy="120" r="6" />
+        <circle cx="110" cy="130" r="5" />
+        <circle cx="160" cy="120" r="4" />
+      </g>
+      <g stroke="${accent}" stroke-opacity="0.25" stroke-width="3" stroke-linecap="round">
+        <line x1="60" y1="70" x2="75" y2="85" />
+        <line x1="75" y1="70" x2="60" y2="85" />
+        <line x1="140" y1="90" x2="155" y2="105" />
+        <line x1="155" y1="90" x2="140" y2="105" />
+      </g>
+    </svg>
+  `)
+
+const createThunderPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g fill="${color}" fill-opacity="0.3">
+        <polygon points="60,20 90,20 70,70 100,70 50,160 70,90 40,90" />
+      </g>
+      <g fill="${accent}" fill-opacity="0.25">
+        <polygon points="140,40 170,40 150,90 180,90 130,170 150,110 120,110" />
+      </g>
+    </svg>
+  `)
+
+const createConfettiPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g fill="${color}" fill-opacity="0.35">
+        <rect x="20" y="30" width="12" height="12" rx="2" />
+        <circle cx="70" cy="50" r="6" />
+        <rect x="120" y="40" width="10" height="10" rx="2" />
+        <circle cx="170" cy="30" r="5" />
+        <rect x="40" y="120" width="12" height="12" rx="2" />
+        <circle cx="90" cy="140" r="6" />
+        <rect x="150" y="130" width="10" height="10" rx="2" />
+      </g>
+      <g fill="${accent}" fill-opacity="0.25">
+        <circle cx="40" cy="70" r="5" />
+        <rect x="90" y="90" width="10" height="10" rx="2" />
+        <circle cx="140" cy="80" r="5" />
+        <rect x="170" y="100" width="8" height="8" rx="2" />
+      </g>
+    </svg>
+  `)
+
+const createStarPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g fill="${color}" fill-opacity="0.35">
+        <polygon points="50,20 56,38 75,38 60,50 66,68 50,57 34,68 40,50 25,38 44,38" />
+        <polygon points="140,110 146,128 165,128 150,140 156,158 140,147 124,158 130,140 115,128 134,128" />
+      </g>
+      <g fill="${accent}" fill-opacity="0.25">
+        <polygon points="120,30 124,42 136,42 126,50 130,62 120,55 110,62 114,50 104,42 116,42" />
+        <circle cx="40" cy="140" r="6" />
+      </g>
+    </svg>
+  `)
+
+const createLeafPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <path d="M40 40 C60 20, 90 20, 110 40 C90 60, 60 70, 40 40Z" fill="${color}" fill-opacity="0.35" />
+      <path d="M120 120 C140 100, 170 100, 190 120 C170 140, 140 150, 120 120Z" fill="${accent}" fill-opacity="0.25" />
+      <path d="M70 130 C80 110, 110 110, 120 130 C110 150, 80 160, 70 130Z" fill="${color}" fill-opacity="0.3" />
+    </svg>
+  `)
+
+const createBubblePattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g fill="none" stroke="${color}" stroke-opacity="0.35" stroke-width="4">
+        <circle cx="50" cy="50" r="18" />
+        <circle cx="140" cy="60" r="14" />
+        <circle cx="80" cy="140" r="20" />
+      </g>
+      <g fill="none" stroke="${accent}" stroke-opacity="0.25" stroke-width="3">
+        <circle cx="120" cy="120" r="12" />
+        <circle cx="30" cy="130" r="10" />
+      </g>
+    </svg>
+  `)
+
+const createHeartPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <path d="M60 40 C60 20, 90 20, 90 45 C90 20, 120 20, 120 40 C120 70, 90 90, 90 90 C90 90, 60 70, 60 40Z" fill="${color}" fill-opacity="0.3" />
+      <path d="M130 120 C130 105, 150 105, 150 120 C150 105, 170 105, 170 120 C170 140, 150 155, 150 155 C150 155, 130 140, 130 120Z" fill="${accent}" fill-opacity="0.25" />
+    </svg>
+  `)
+
+const createCandyPattern = (color: string, accent: string) =>
+  toDataUri(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+      <g fill="${color}" fill-opacity="0.35">
+        <rect x="30" y="30" width="30" height="12" rx="6" />
+        <rect x="90" y="50" width="30" height="12" rx="6" />
+        <rect x="140" y="30" width="30" height="12" rx="6" />
+      </g>
+      <g fill="${accent}" fill-opacity="0.25">
+        <circle cx="60" cy="120" r="10" />
+        <circle cx="120" cy="140" r="8" />
+        <circle cx="170" cy="120" r="9" />
+      </g>
+    </svg>
+  `)
+
+const weatherWallpaperSets: Record<WeatherWallpaperType, WallpaperDefinition[]> = {
+  clear: [
+    {
+      id: 'clear-sunrise',
+      label: 'Sunny Sunrise',
+      category: 'weather',
+      weatherType: 'clear',
+      gradient: 'linear-gradient(135deg, #fff3c7 0%, #ffd6b5 40%, #b7e3ff 100%)',
+      pattern: createSunPattern('#ffb703', '#ffd166'),
+    },
+    {
+      id: 'clear-noon',
+      label: 'Bright Noon',
+      category: 'weather',
+      weatherType: 'clear',
+      gradient: 'linear-gradient(135deg, #d7f5ff 0%, #a9e5ff 45%, #ffe29a 100%)',
+      pattern: createSunPattern('#ffd166', '#90e0ef'),
+    },
+    {
+      id: 'clear-lagoon',
+      label: 'Lagoon Shine',
+      category: 'weather',
+      weatherType: 'clear',
+      gradient: 'linear-gradient(135deg, #fef9c3 0%, #bef264 45%, #7dd3fc 100%)',
+      pattern: createSunPattern('#facc15', '#38bdf8'),
+    },
+    {
+      id: 'clear-golden',
+      label: 'Golden Glow',
+      category: 'weather',
+      weatherType: 'clear',
+      gradient: 'linear-gradient(135deg, #fde68a 0%, #fca5a5 45%, #bae6fd 100%)',
+      pattern: createSunPattern('#f97316', '#fb7185'),
+    },
+    {
+      id: 'clear-picnic',
+      label: 'Picnic Sky',
+      category: 'weather',
+      weatherType: 'clear',
+      gradient: 'linear-gradient(135deg, #c7f9cc 0%, #90dbf4 40%, #fbc4ab 100%)',
+      pattern: createSunPattern('#f59e0b', '#22d3ee'),
+    },
+  ],
+  'partly-cloudy': [
+    {
+      id: 'partly-soft',
+      label: 'Soft Clouds',
+      category: 'weather',
+      weatherType: 'partly-cloudy',
+      gradient: 'linear-gradient(135deg, #e2f3ff 0%, #d4e9ff 40%, #f7d6e0 100%)',
+      pattern: createCloudPattern('#b3c7f9', '#fbcfe8'),
+    },
+    {
+      id: 'partly-breeze',
+      label: 'Breezy Day',
+      category: 'weather',
+      weatherType: 'partly-cloudy',
+      gradient: 'linear-gradient(135deg, #e0f2fe 0%, #bae6fd 45%, #fef3c7 100%)',
+      pattern: createCloudPattern('#93c5fd', '#fcd34d'),
+    },
+    {
+      id: 'partly-sweet',
+      label: 'Cotton Candy',
+      category: 'weather',
+      weatherType: 'partly-cloudy',
+      gradient: 'linear-gradient(135deg, #fce7f3 0%, #dbeafe 50%, #fde68a 100%)',
+      pattern: createCloudPattern('#a5b4fc', '#f9a8d4'),
+    },
+    {
+      id: 'partly-skyline',
+      label: 'Skyline Breeze',
+      category: 'weather',
+      weatherType: 'partly-cloudy',
+      gradient: 'linear-gradient(135deg, #dbeafe 0%, #c7d2fe 40%, #fed7aa 100%)',
+      pattern: createCloudPattern('#93c5fd', '#fb7185'),
+    },
+    {
+      id: 'partly-pastel',
+      label: 'Pastel Puff',
+      category: 'weather',
+      weatherType: 'partly-cloudy',
+      gradient: 'linear-gradient(135deg, #e9d5ff 0%, #bae6fd 50%, #fde68a 100%)',
+      pattern: createCloudPattern('#c4b5fd', '#fcd34d'),
+    },
+  ],
+  cloudy: [
+    {
+      id: 'cloudy-slate',
+      label: 'Slate Clouds',
+      category: 'weather',
+      weatherType: 'cloudy',
+      gradient: 'linear-gradient(135deg, #e2e8f0 0%, #cbd5f5 45%, #f8fafc 100%)',
+      pattern: createCloudPattern('#94a3b8', '#cbd5e1'),
+    },
+    {
+      id: 'cloudy-lavender',
+      label: 'Lavender Overcast',
+      category: 'weather',
+      weatherType: 'cloudy',
+      gradient: 'linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 40%, #e9d5ff 100%)',
+      pattern: createCloudPattern('#94a3b8', '#c4b5fd'),
+    },
+    {
+      id: 'cloudy-mint',
+      label: 'Minty Overcast',
+      category: 'weather',
+      weatherType: 'cloudy',
+      gradient: 'linear-gradient(135deg, #ecfeff 0%, #e2e8f0 45%, #f0f9ff 100%)',
+      pattern: createCloudPattern('#94a3b8', '#7dd3fc'),
+    },
+    {
+      id: 'cloudy-cocoa',
+      label: 'Cocoa Clouds',
+      category: 'weather',
+      weatherType: 'cloudy',
+      gradient: 'linear-gradient(135deg, #fef3c7 0%, #e2e8f0 45%, #fed7aa 100%)',
+      pattern: createCloudPattern('#cbd5e1', '#f59e0b'),
+    },
+    {
+      id: 'cloudy-bluebell',
+      label: 'Bluebell Haze',
+      category: 'weather',
+      weatherType: 'cloudy',
+      gradient: 'linear-gradient(135deg, #dbeafe 0%, #e2e8f0 45%, #f1f5f9 100%)',
+      pattern: createCloudPattern('#94a3b8', '#60a5fa'),
+    },
+  ],
+  fog: [
+    {
+      id: 'fog-soft',
+      label: 'Soft Fog',
+      category: 'weather',
+      weatherType: 'fog',
+      gradient: 'linear-gradient(135deg, #f8fafc 0%, #e2e8f0 45%, #e0f2fe 100%)',
+      pattern: createFogPattern('#94a3b8', '#cbd5e1'),
+    },
+    {
+      id: 'fog-mist',
+      label: 'Morning Mist',
+      category: 'weather',
+      weatherType: 'fog',
+      gradient: 'linear-gradient(135deg, #e0f2fe 0%, #e2e8f0 45%, #f1f5f9 100%)',
+      pattern: createFogPattern('#94a3b8', '#bae6fd'),
+    },
+    {
+      id: 'fog-quiet',
+      label: 'Quiet Haze',
+      category: 'weather',
+      weatherType: 'fog',
+      gradient: 'linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 50%, #e9d5ff 100%)',
+      pattern: createFogPattern('#a1a1aa', '#c4b5fd'),
+    },
+    {
+      id: 'fog-seafoam',
+      label: 'Seafoam Mist',
+      category: 'weather',
+      weatherType: 'fog',
+      gradient: 'linear-gradient(135deg, #ecfeff 0%, #e2e8f0 45%, #fef3c7 100%)',
+      pattern: createFogPattern('#94a3b8', '#67e8f9'),
+    },
+    {
+      id: 'fog-peach',
+      label: 'Peach Fog',
+      category: 'weather',
+      weatherType: 'fog',
+      gradient: 'linear-gradient(135deg, #ffe4e6 0%, #e2e8f0 45%, #fef9c3 100%)',
+      pattern: createFogPattern('#94a3b8', '#fda4af'),
+    },
+  ],
+  drizzle: [
+    {
+      id: 'drizzle-sprinkle',
+      label: 'Sprinkle Showers',
+      category: 'weather',
+      weatherType: 'drizzle',
+      gradient: 'linear-gradient(135deg, #e0f2fe 0%, #bae6fd 45%, #fef3c7 100%)',
+      pattern: createDrizzlePattern('#60a5fa', '#38bdf8'),
+    },
+    {
+      id: 'drizzle-garden',
+      label: 'Garden Drizzle',
+      category: 'weather',
+      weatherType: 'drizzle',
+      gradient: 'linear-gradient(135deg, #dcfce7 0%, #bae6fd 45%, #fef9c3 100%)',
+      pattern: createDrizzlePattern('#34d399', '#60a5fa'),
+    },
+    {
+      id: 'drizzle-dawn',
+      label: 'Dawn Drizzle',
+      category: 'weather',
+      weatherType: 'drizzle',
+      gradient: 'linear-gradient(135deg, #fce7f3 0%, #bae6fd 45%, #dbeafe 100%)',
+      pattern: createDrizzlePattern('#f472b6', '#60a5fa'),
+    },
+    {
+      id: 'drizzle-sky',
+      label: 'Sky Drizzle',
+      category: 'weather',
+      weatherType: 'drizzle',
+      gradient: 'linear-gradient(135deg, #dbeafe 0%, #93c5fd 40%, #e9d5ff 100%)',
+      pattern: createDrizzlePattern('#60a5fa', '#a78bfa'),
+    },
+    {
+      id: 'drizzle-puddle',
+      label: 'Puddle Play',
+      category: 'weather',
+      weatherType: 'drizzle',
+      gradient: 'linear-gradient(135deg, #cffafe 0%, #bae6fd 45%, #fee2e2 100%)',
+      pattern: createDrizzlePattern('#38bdf8', '#fb7185'),
+    },
+  ],
+  rain: [
+    {
+      id: 'rain-umbrella',
+      label: 'Umbrella Parade',
+      category: 'weather',
+      weatherType: 'rain',
+      gradient: 'linear-gradient(135deg, #bae6fd 0%, #93c5fd 45%, #f1f5f9 100%)',
+      pattern: createRainPattern('#3b82f6', '#60a5fa'),
+    },
+    {
+      id: 'rain-midnight',
+      label: 'Midnight Rain',
+      category: 'weather',
+      weatherType: 'rain',
+      gradient: 'linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #93c5fd 100%)',
+      pattern: createRainPattern('#93c5fd', '#bfdbfe'),
+    },
+    {
+      id: 'rain-slate',
+      label: 'Slate Rain',
+      category: 'weather',
+      weatherType: 'rain',
+      gradient: 'linear-gradient(135deg, #94a3b8 0%, #64748b 45%, #e2e8f0 100%)',
+      pattern: createRainPattern('#e2e8f0', '#94a3b8'),
+    },
+    {
+      id: 'rain-berry',
+      label: 'Berry Storm',
+      category: 'weather',
+      weatherType: 'rain',
+      gradient: 'linear-gradient(135deg, #c7d2fe 0%, #a5b4fc 40%, #fbcfe8 100%)',
+      pattern: createRainPattern('#6366f1', '#f472b6'),
+    },
+    {
+      id: 'rain-sea',
+      label: 'Sea Rain',
+      category: 'weather',
+      weatherType: 'rain',
+      gradient: 'linear-gradient(135deg, #bae6fd 0%, #7dd3fc 40%, #f0f9ff 100%)',
+      pattern: createRainPattern('#0ea5e9', '#38bdf8'),
+    },
+  ],
+  snow: [
+    {
+      id: 'snow-day',
+      label: 'Snow Day',
+      category: 'weather',
+      weatherType: 'snow',
+      gradient: 'linear-gradient(135deg, #f8fafc 0%, #e2e8f0 45%, #bfdbfe 100%)',
+      pattern: createSnowPattern('#93c5fd', '#e2e8f0'),
+    },
+    {
+      id: 'snowberry',
+      label: 'Snowberry',
+      category: 'weather',
+      weatherType: 'snow',
+      gradient: 'linear-gradient(135deg, #f5f3ff 0%, #e0e7ff 45%, #dbeafe 100%)',
+      pattern: createSnowPattern('#a5b4fc', '#c7d2fe'),
+    },
+    {
+      id: 'snowy-mint',
+      label: 'Snowy Mint',
+      category: 'weather',
+      weatherType: 'snow',
+      gradient: 'linear-gradient(135deg, #ecfeff 0%, #e2e8f0 45%, #e0f2fe 100%)',
+      pattern: createSnowPattern('#7dd3fc', '#bae6fd'),
+    },
+    {
+      id: 'snow-lilac',
+      label: 'Lilac Snow',
+      category: 'weather',
+      weatherType: 'snow',
+      gradient: 'linear-gradient(135deg, #ede9fe 0%, #e2e8f0 45%, #fdf2f8 100%)',
+      pattern: createSnowPattern('#c4b5fd', '#fbcfe8'),
+    },
+    {
+      id: 'snow-hush',
+      label: 'Hushed Snow',
+      category: 'weather',
+      weatherType: 'snow',
+      gradient: 'linear-gradient(135deg, #f8fafc 0%, #e2e8f0 45%, #f1f5f9 100%)',
+      pattern: createSnowPattern('#cbd5f5', '#e2e8f0'),
+    },
+  ],
+  thunder: [
+    {
+      id: 'thunder-punch',
+      label: 'Thunder Punch',
+      category: 'weather',
+      weatherType: 'thunder',
+      gradient: 'linear-gradient(135deg, #312e81 0%, #1e1b4b 45%, #9333ea 100%)',
+      pattern: createThunderPattern('#fbbf24', '#facc15'),
+    },
+    {
+      id: 'thunder-glow',
+      label: 'Electric Glow',
+      category: 'weather',
+      weatherType: 'thunder',
+      gradient: 'linear-gradient(135deg, #1e293b 0%, #334155 45%, #0ea5e9 100%)',
+      pattern: createThunderPattern('#f59e0b', '#38bdf8'),
+    },
+    {
+      id: 'thunder-violet',
+      label: 'Violet Storm',
+      category: 'weather',
+      weatherType: 'thunder',
+      gradient: 'linear-gradient(135deg, #2e1065 0%, #4c1d95 45%, #7c3aed 100%)',
+      pattern: createThunderPattern('#fde047', '#fbbf24'),
+    },
+    {
+      id: 'thunder-spark',
+      label: 'Spark Storm',
+      category: 'weather',
+      weatherType: 'thunder',
+      gradient: 'linear-gradient(135deg, #0f172a 0%, #1f2937 45%, #334155 100%)',
+      pattern: createThunderPattern('#facc15', '#f97316'),
+    },
+    {
+      id: 'thunder-neon',
+      label: 'Neon Storm',
+      category: 'weather',
+      weatherType: 'thunder',
+      gradient: 'linear-gradient(135deg, #0f172a 0%, #1e3a8a 45%, #2563eb 100%)',
+      pattern: createThunderPattern('#fde047', '#22d3ee'),
+    },
+  ],
+}
+
+const nonWeatherWallpapers: WallpaperDefinition[] = [
+  {
+    id: 'confetti-party',
+    label: 'Confetti Party',
+    category: 'non-weather',
+    gradient: 'linear-gradient(135deg, #fde68a 0%, #fbcfe8 45%, #bae6fd 100%)',
+    pattern: createConfettiPattern('#f97316', '#6366f1'),
+  },
+  {
+    id: 'starry-night',
+    label: 'Starry Night',
+    category: 'non-weather',
+    gradient: 'linear-gradient(135deg, #0f172a 0%, #1e1b4b 45%, #312e81 100%)',
+    pattern: createStarPattern('#facc15', '#60a5fa'),
+  },
+  {
+    id: 'leafy-play',
+    label: 'Leafy Play',
+    category: 'non-weather',
+    gradient: 'linear-gradient(135deg, #bbf7d0 0%, #86efac 45%, #fef08a 100%)',
+    pattern: createLeafPattern('#22c55e', '#facc15'),
+  },
+  {
+    id: 'bubble-breeze',
+    label: 'Bubble Breeze',
+    category: 'non-weather',
+    gradient: 'linear-gradient(135deg, #cffafe 0%, #bae6fd 45%, #f0f9ff 100%)',
+    pattern: createBubblePattern('#38bdf8', '#7dd3fc'),
+  },
+  {
+    id: 'hearts-happy',
+    label: 'Happy Hearts',
+    category: 'non-weather',
+    gradient: 'linear-gradient(135deg, #fbcfe8 0%, #fecdd3 45%, #fef3c7 100%)',
+    pattern: createHeartPattern('#fb7185', '#fda4af'),
+  },
+  {
+    id: 'candy-crush',
+    label: 'Candy Clouds',
+    category: 'non-weather',
+    gradient: 'linear-gradient(135deg, #fef3c7 0%, #fde68a 45%, #fbcfe8 100%)',
+    pattern: createCandyPattern('#f97316', '#f472b6'),
+  },
+  {
+    id: 'dreamy-dusk',
+    label: 'Dreamy Dusk',
+    category: 'non-weather',
+    gradient: 'linear-gradient(135deg, #c7d2fe 0%, #a5b4fc 45%, #fbcfe8 100%)',
+    pattern: createStarPattern('#a855f7', '#f472b6'),
+  },
+  {
+    id: 'playful-mosaic',
+    label: 'Playful Mosaic',
+    category: 'non-weather',
+    gradient: 'linear-gradient(135deg, #fde68a 0%, #a7f3d0 45%, #bfdbfe 100%)',
+    pattern: createConfettiPattern('#10b981', '#3b82f6'),
+  },
+]
+
+const flattenWeatherWallpapers = () => Object.values(weatherWallpaperSets).flat()
+
+export const getWeatherWallpaperType = (conditionCode: number | undefined | null): WeatherWallpaperType | null => {
+  if (conditionCode === null || conditionCode === undefined) return null
+  if (conditionCode === 0) return 'clear'
+  if (conditionCode === 1 || conditionCode === 2) return 'partly-cloudy'
+  if (conditionCode === 3) return 'cloudy'
+  if (conditionCode >= 45 && conditionCode <= 48) return 'fog'
+  if (conditionCode >= 51 && conditionCode <= 57) return 'drizzle'
+  if ((conditionCode >= 61 && conditionCode <= 67) || (conditionCode >= 80 && conditionCode <= 82)) return 'rain'
+  if ((conditionCode >= 71 && conditionCode <= 77) || (conditionCode >= 85 && conditionCode <= 86)) return 'snow'
+  if (conditionCode >= 95 && conditionCode <= 99) return 'thunder'
+  return 'clear'
+}
+
+const pickBySeed = <T,>(items: T[], seed: number) => {
+  if (items.length === 0) return null
+  const index = Math.abs(seed) % items.length
+  return items[index]
+}
+
+const hashSeed = (value: string) =>
+  value.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+
+const buildWallpaperStyle = (wallpaper: WallpaperDefinition): CSSProperties => {
+  const accentLayer = wallpaper.accentPattern ? `, url("${wallpaper.accentPattern}")` : ''
+  const accentSize = wallpaper.accentSize ? `, ${wallpaper.accentSize}` : ''
+  const basePatternSize = wallpaper.patternSize || '260px 260px'
+
+  return {
+    backgroundImage: `${wallpaper.gradient}, url("${wallpaper.pattern}")${accentLayer}`,
+    backgroundSize: `cover, ${basePatternSize}${accentSize}`,
+    backgroundRepeat: `no-repeat, repeat${accentLayer ? ', repeat' : ''}`,
+    backgroundPosition: `center, 0 0${accentLayer ? ', 40px 20px' : ''}`,
+  }
+}
+
+export const getWallpaperSelection = ({
+  settings,
+  deviceMode,
+  weather,
+  seedKey,
+}: {
+  settings: WallpaperSettings
+  deviceMode: WallpaperMode
+  weather: WeatherData | null
+  seedKey: string
+}): WallpaperSelection | null => {
+  if (!settings.enabled) return null
+
+  const weatherType = getWeatherWallpaperType(weather?.conditionCode ?? null)
+  const weatherWallpapers = weatherType ? weatherWallpaperSets[weatherType] : []
+  const weatherAllowed = settings.weatherWallpapersEnabled && weatherWallpapers.length > 0
+  const nonWeatherAllowed = settings.nonWeatherWallpapersEnabled
+
+  let candidates: WallpaperDefinition[] = []
+
+  if (deviceMode === 'weather' && weatherAllowed) {
+    candidates = weatherWallpapers
+  } else if (deviceMode === 'non-weather' && nonWeatherAllowed) {
+    candidates = nonWeatherWallpapers
+  } else if (weatherAllowed) {
+    candidates = weatherWallpapers
+  } else if (nonWeatherAllowed) {
+    candidates = nonWeatherWallpapers
+  }
+
+  if (candidates.length === 0) return null
+
+  const seed = hashSeed(`${seedKey}-${deviceMode}-${weatherType ?? 'none'}`)
+  const wallpaper = pickBySeed(candidates, seed)
+  if (!wallpaper) return null
+
+  return {
+    id: wallpaper.id,
+    label: wallpaper.label,
+    category: wallpaper.category,
+    style: buildWallpaperStyle(wallpaper),
+  }
+}
+
+export const getDefaultWallpaperMode = (settings: WallpaperSettings) => settings.defaultMode
+
+export const getDeviceWallpaperMode = ({
+  settings,
+  deviceMode,
+}: {
+  settings: WallpaperSettings
+  deviceMode?: WallpaperMode
+}): WallpaperMode => deviceMode ?? settings.defaultMode
+
+export const weatherWallpaperCountByType = Object.fromEntries(
+  Object.entries(weatherWallpaperSets).map(([key, value]) => [key, value.length])
+) as Record<WeatherWallpaperType, number>
+
+export const nonWeatherWallpaperCount = nonWeatherWallpapers.length
+
+export const allWeatherWallpapers = flattenWeatherWallpapers()
+
+export const allNonWeatherWallpapers = nonWeatherWallpapers

--- a/src/main.css
+++ b/src/main.css
@@ -184,3 +184,43 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes wallpaper-drift {
+  0% {
+    background-position: center, 0 0, 40px 20px;
+  }
+  50% {
+    background-position: center, 120px 80px, -40px 60px;
+  }
+  100% {
+    background-position: center, 0 0, 40px 20px;
+  }
+}
+
+@keyframes wallpaper-glow {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+.wallpaper-surface {
+  position: relative;
+  background-repeat: no-repeat, repeat, repeat;
+}
+
+.wallpaper-animate {
+  animation: wallpaper-drift 60s linear infinite;
+}
+
+.wallpaper-overlay {
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  mix-blend-mode: soft-light;
+}
+
+.wallpaper-overlay-animate {
+  animation: wallpaper-glow 14s ease-in-out infinite;
+}


### PR DESCRIPTION
### Motivation
- Provide playful, child-friendly background wallpapers for the main child views with weather-aware selections and gentle animations. 
- Give parents a single place to enable/disable wallpapers and control whether weather or non-weather themes are used globally and per linked device.

### Description
- Added a wallpaper library `src/lib/wallpaperLibrary.ts` containing 5+ SVG-based weather-themed sets per weather type and multiple non-weather wallpapers, plus deterministic selection logic (`getWallpaperSelection`, `getWeatherWallpaperType`).
- Introduced new types in `src/lib/types.ts` (`WallpaperSettings`, `DeviceWallpaperSettingsMap`, `WallpaperMode`) and KV keys in `src/App.tsx` to persist `wallpaper-settings` and `device-wallpaper-settings` with wallpapers enabled by default.
- Implemented `WallpaperSurface` (`src/components/WallpaperSurface.tsx`) which applies the selected wallpaper style and overlay/animation, and wrapped the child-facing views (`ChildSelector`, `ChildChoreView`) to render wallpapers per device and current weather.
- Added a Parent Dashboard page `WallpaperSettingsPanel` (`src/components/WallpaperSettingsPanel.tsx`) and integrated it into the Settings tabs in `ParentPanel`, providing toggles for global enable, weather/non-weather sets, animation, default mode, and per-linked-device mode selectors.
- Added CSS for subtle wallpaper animations/overlay in `src/main.css` and data-URI SVG pattern helpers to keep backgrounds lightweight and child-appropriate.

### Testing
- Started the dev server with `npm run dev` and validated the UI served by loading the front page; Vite reported the app served at `http://localhost:5000/` and the page rendered (some API proxy errors were observed in logs but did not prevent the UI from loading). (Succeeded)
- Captured a UI screenshot via a Playwright script to confirm wallpapers render; the script produced `artifacts/wallpaper-page.png`. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69854530113483328e801a82e29d3407)