### PR TITLE
Increase nginx upload size limit for wallpaper uploads

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,7 @@ server {
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+    client_max_body_size 20m;
 
     # Docker DNS resolver for dynamic upstream resolution
     resolver 127.0.0.11 valid=30s ipv6=off;


### PR DESCRIPTION
### Motivation
- Prevent 413 "Content Too Large" errors when admins upload wallpaper images or videos by allowing larger request bodies to reach the backend.

### Description
- Add `client_max_body_size 20m` to `nginx.conf` server block to raise the Nginx upload limit to 20 megabytes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69855c3eb0a08332ab44df386136d905)