### PR TITLE
Serve uploaded wallpapers via /uploads proxy (nginx & Vite)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -46,6 +46,20 @@ server {
         add_header Expires "0" always;
     }
 
+    # Wallpaper uploads proxy to backend
+    location /uploads/ {
+        proxy_pass http://$upstream_api$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
     # Spark KV proxy to backend (for @github/spark useKV hook)
     # Note: Proxy settings are intentionally duplicated from /api/ block above
     # to maintain clarity and avoid include file complexity

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,10 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true,
+      },
+      '/uploads': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
       }
     }
   },


### PR DESCRIPTION
### Motivation
- Uploaded image and video wallpapers were not reachable by parent clients because the uploads path was not proxied to the backend, causing broken image icons and blank videos.

### Description
- Add an Nginx `location /uploads/` block that proxies requests to the backend (`api:3000`) and applies long-lived public cache headers for static uploaded assets.
- Add a Vite dev server proxy for `/uploads` pointing to `http://localhost:3000` so local development resolves uploaded assets the same way as production.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69855ec6ccfc833297488175912ef7e5)